### PR TITLE
fix: sprint report links missing slash

### DIFF
--- a/src/pages/reports/sprint/_SprintLayout.astro
+++ b/src/pages/reports/sprint/_SprintLayout.astro
@@ -11,7 +11,8 @@ interface Props {
 
 const { title, concept, activeScreen, description } = Astro.props;
 
-const base = import.meta.env.BASE_URL; // e.g. /lbdc-website/
+const rawBase = import.meta.env.BASE_URL; // Astro may provide '/lbdc-website' (no trailing slash)
+const base = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
 const sprintRoot = `${base}reports/sprint/`;
 
 const screens: Array<{ key: ScreenKey; name: string; href: (c: ConceptKey) => string }> = [

--- a/src/pages/reports/sprint/index.astro
+++ b/src/pages/reports/sprint/index.astro
@@ -2,7 +2,8 @@
 import SprintLayout from './_SprintLayout.astro';
 import { concepts } from './_data';
 
-const base = import.meta.env.BASE_URL;
+const rawBase = import.meta.env.BASE_URL;
+const base = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
 const sprintRoot = `${base}reports/sprint/`;
 ---
 


### PR DESCRIPTION
Fixes a BASE_URL join edge case where some sprint report links rendered as `/lbdc-websitereports/...` instead of `/lbdc-website/reports/...`.

Implementation: normalise `import.meta.env.BASE_URL` to always end with `/` before concatenation.
