### PR TITLE
style: fix sprint overview list alignment

### DIFF
--- a/src/pages/reports/sprint/index.astro
+++ b/src/pages/reports/sprint/index.astro
@@ -50,6 +50,9 @@ const sprintRoot = `${base}reports/sprint/`;
   </section>
 
   <style>
+    /* Make ordered lists feel properly inset (avoids hugging the left edge) */
+    ol{padding-left:28px;}
+
     .hero{padding:12px 0 10px;}
     .kicker{font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:rgba(0,0,0,.60)}
     h1{margin:10px 0 12px;font-size:52px;line-height:1.06;letter-spacing:-0.03em;color:#111}


### PR DESCRIPTION
Adjusts the ordered-list padding on the sprint overview page so the numbering doesn’t hug the left edge.
