### PR TITLE
fix: sprint comparison links + broken screenshots

### DIFF
--- a/src/pages/reports/sprint/compare.astro
+++ b/src/pages/reports/sprint/compare.astro
@@ -2,7 +2,8 @@
 import SprintLayout from './_SprintLayout.astro';
 import { concepts, screens } from './_data';
 
-const base = import.meta.env.BASE_URL;
+const rawBase = import.meta.env.BASE_URL;
+const base = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
 const sprintRoot = `${base}reports/sprint/`;
 ---
 

--- a/src/pages/reports/sprint/concepts/[concept]/[screen].astro
+++ b/src/pages/reports/sprint/concepts/[concept]/[screen].astro
@@ -21,7 +21,8 @@ if (!validScreens.includes(sk)) {
   throw new Error(`Invalid screen: ${screen}`);
 }
 
-const base = import.meta.env.BASE_URL;
+const rawBase = import.meta.env.BASE_URL;
+const base = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
 const imgDesktop = `${base}reports/sprint/screens/${c.key}-${sk}-1280.png`;
 const imgMobile = `${base}reports/sprint/screens/${c.key}-${sk}-375.png`;
 


### PR DESCRIPTION
Fixes two BASE_URL join issues in the sprint report:

1) Comparison table “View” links were generating `/lbdc-websitereports/...`
2) Concept pages’ screenshot image src paths were also missing the slash, causing broken images

Normalises BASE_URL to always end with `/` before concatenation.
