### PR TITLE
feat: Concept A deep redesign (modern consulting homepage)

### DIFF
--- a/public/tokens-deep-a.css
+++ b/public/tokens-deep-a.css
@@ -1,0 +1,54 @@
+/**
+ * Concept A Deep — "Modern Consulting"
+ * Palette A (teal accent) × MetaLab/barvere art direction.
+ *
+ * Design principles:
+ * - Typography does the heavy lifting. Scale is aggressive, tracking tight.
+ * - White canvas. No shadows. Hairline lines, not box borders.
+ * - Teal accent used ONCE per fold for maximum signal strength.
+ * - Extreme whitespace between sections (sections breathe).
+ * - Grid = implicit. No heavy card chrome.
+ */
+
+:root {
+  /* Canvas */
+  --da-bg:        #FAFAF8;
+  --da-surface:   #FFFFFF;
+  --da-ink:       #111210;
+  --da-ink-muted: rgba(17, 18, 16, 0.55);
+  --da-ink-faint: rgba(17, 18, 16, 0.22);
+  --da-line:      rgba(17, 18, 16, 0.10);
+  --da-line-mid:  rgba(17, 18, 16, 0.18);
+
+  /* Accent — used sparingly */
+  --da-accent:     #2F6F73;
+  --da-accent-dim: rgba(47, 111, 115, 0.12);
+
+  /* Type scale */
+  --da-font:        -apple-system, BlinkMacSystemFont, 'Inter', 'Helvetica Neue', Arial, sans-serif;
+
+  --da-display:     clamp(52px, 8vw, 96px);   /* Hero H1 */
+  --da-h2:          clamp(32px, 4vw, 48px);   /* Section heads */
+  --da-h3:          18px;                      /* Pillar titles */
+  --da-body-lg:     18px;
+  --da-body:        16px;
+  --da-label:       12px;
+
+  --da-track-tight: -0.04em;
+  --da-track-head:  -0.02em;
+  --da-track-label: 0.12em;
+
+  --da-lead-tight:  1.05;
+  --da-lead-body:   1.65;
+
+  /* Spacing rhythm */
+  --da-section: clamp(80px, 10vw, 128px);
+  --da-gap:     clamp(40px, 5vw, 64px);
+
+  /* Radius (sharp, editorial) */
+  --da-r-sm: 2px;
+  --da-r:    6px;
+
+  /* Transitions */
+  --da-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}

--- a/src/pages/concept-a/index.astro
+++ b/src/pages/concept-a/index.astro
@@ -1,0 +1,566 @@
+---
+/**
+ * Concept A — Deep "Modern Consulting" homepage
+ * Art direction: MetaLab × barvere.co.za
+ * Palette A (cool-charcoal ink, off-white canvas, teal accent — used once per fold)
+ */
+---
+<!doctype html>
+<html lang="en-ZA">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LBDC — Strategic Advisory</title>
+    <meta name="description" content="Strategic advisory for growth-stage businesses. Clear thinking, practical systems, measurable outcomes." />
+    <link rel="stylesheet" href="/lbdc-website/tokens-deep-a.css" />
+  </head>
+  <body>
+
+    <!-- NAV ─────────────────────────────────────────────────────── -->
+    <nav class="nav">
+      <a class="nav__brand" href="/">LBDC</a>
+      <div class="nav__links">
+        <a href="#services">Services</a>
+        <a href="#about">About</a>
+        <a class="nav__cta" href="#contact">Get in touch</a>
+      </div>
+    </nav>
+
+    <!-- HERO ────────────────────────────────────────────────────── -->
+    <section class="hero section">
+      <div class="hero__label label">Strategic advisory</div>
+      <h1 class="hero__h1">
+        Clear thinking.<br>
+        Practical systems.<br>
+        Measurable outcomes.
+      </h1>
+      <p class="hero__sub">
+        LeRoy Barnes works directly with growth-stage businesses to align strategy,
+        delivery cadence, and operating rhythm — without the theatre.
+      </p>
+      <div class="hero__actions">
+        <a class="btn btn--primary" href="#contact">Get in touch</a>
+        <a class="btn btn--ghost" href="#services">See services →</a>
+      </div>
+      <!-- Proof ribbon -->
+      <div class="proof" aria-label="Anonymised track record">
+        <div class="proof__item">
+          <span class="proof__num">10</span>
+          <span class="proof__text">country Pan-African<br>operations led</span>
+        </div>
+        <div class="proof__div" aria-hidden="true"></div>
+        <div class="proof__item">
+          <span class="proof__num">13×</span>
+          <span class="proof__text">faster delivery cadence<br>achieved</span>
+        </div>
+        <div class="proof__div" aria-hidden="true"></div>
+        <div class="proof__item">
+          <span class="proof__num">+50%</span>
+          <span class="proof__text">customer satisfaction<br>improvement</span>
+        </div>
+        <div class="proof__div" aria-hidden="true"></div>
+        <div class="proof__item">
+          <span class="proof__num">R320m</span>
+          <span class="proof__text">P&amp;L responsibility<br>held</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- SERVICES ────────────────────────────────────────────────── -->
+    <section class="section services" id="services">
+      <div class="section__header">
+        <div class="label">What he does</div>
+        <h2>Three ways to work<br>with LeRoy</h2>
+      </div>
+
+      <div class="services__grid">
+        <article class="svc">
+          <div class="svc__num">01</div>
+          <h3 class="svc__title">Strategy &amp; operating model</h3>
+          <p class="svc__body">
+            Translate ambition into a clear operating model — priorities, decision rights,
+            and the rhythms that keep teams aligned under pressure.
+          </p>
+          <a class="svc__link" href="#contact">Enquire →</a>
+        </article>
+        <article class="svc">
+          <div class="svc__num">02</div>
+          <h3 class="svc__title">Product &amp; delivery cadence</h3>
+          <p class="svc__body">
+            Move from chaotic delivery to a predictable, high-velocity operating system.
+            Weekly cadence, real metrics, genuine ownership at every level.
+          </p>
+          <a class="svc__link" href="#contact">Enquire →</a>
+        </article>
+        <article class="svc">
+          <div class="svc__num">03</div>
+          <h3 class="svc__title">Performance &amp; decision intelligence</h3>
+          <p class="svc__body">
+            Surface what actually matters. Design dashboards, reporting layers, and
+            review rituals that drive behaviour — not just compliance.
+          </p>
+          <a class="svc__link" href="#contact">Enquire →</a>
+        </article>
+      </div>
+    </section>
+
+    <!-- HOW HE WORKS ─────────────────────────────────────────────── -->
+    <section class="section how">
+      <div class="section__header">
+        <div class="label">How it works</div>
+        <h2>A clear process,<br>every time</h2>
+      </div>
+
+      <div class="how__steps">
+        <div class="step">
+          <span class="step__n">1</span>
+          <div>
+            <h3 class="step__t">Diagnose</h3>
+            <p class="step__b">Understand the system as it actually works, not as it appears on paper.</p>
+          </div>
+        </div>
+        <div class="step__arrow" aria-hidden="true">→</div>
+        <div class="step">
+          <span class="step__n">2</span>
+          <div>
+            <h3 class="step__t">Design</h3>
+            <p class="step__b">Build the interventions — model, cadence, dashboards — with precision.</p>
+          </div>
+        </div>
+        <div class="step__arrow" aria-hidden="true">→</div>
+        <div class="step">
+          <span class="step__n">3</span>
+          <div>
+            <h3 class="step__t">Deliver</h3>
+            <p class="step__b">Embed, iterate, and hand off — with outcomes that hold after he leaves.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ABOUT ───────────────────────────────────────────────────── -->
+    <section class="section about" id="about">
+      <div class="about__inner">
+        <div class="about__left">
+          <div class="label">About</div>
+          <h2>Founder-led.<br>No junior consultants.</h2>
+          <p>
+            LeRoy Barnes is a pragmatic operator with experience across strategy,
+            product, and delivery — in some of Africa's most complex environments.
+          </p>
+          <p>
+            He works directly with founders and executive teams. No account managers,
+            no padding, no slide decks that gather dust.
+          </p>
+        </div>
+        <div class="about__right">
+          <div class="credential">
+            <div class="credential__label">Experience (anonymised)</div>
+            <ul class="credential__list">
+              <li>Multi-country payments platform (10 markets)</li>
+              <li>Cross-functional digital transformation</li>
+              <li>Executive product leadership at financial institutions</li>
+              <li>Operating cadence that scaled delivery 13×</li>
+            </ul>
+          </div>
+          <div class="credential" style="margin-top:24px">
+            <div class="credential__label">Principles</div>
+            <ul class="credential__list">
+              <li>Clarity beats complexity</li>
+              <li>Systems over heroics</li>
+              <li>Truthful metrics</li>
+              <li>No outputs without outcomes</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- CONTACT ─────────────────────────────────────────────────── -->
+    <section class="section contact" id="contact">
+      <div class="contact__inner">
+        <div class="label">Get in touch</div>
+        <h2>Let's talk about<br>your business.</h2>
+        <p class="contact__sub">
+          Briefly describe what you're trying to achieve.
+          LeRoy responds within one to two business days.
+        </p>
+        <a class="btn btn--primary btn--lg" href="mailto:leroy@lbdc.co.za">leroy@lbdc.co.za →</a>
+        <p class="contact__note">Or use the form below — coming soon.</p>
+      </div>
+    </section>
+
+    <!-- FOOTER ──────────────────────────────────────────────────── -->
+    <footer class="footer">
+      <div class="footer__left">
+        <span class="footer__brand">LBDC</span>
+        <span class="footer__tag">© 2026 LeRoy Barnes</span>
+      </div>
+      <div class="footer__right">
+        <a href="#services">Services</a>
+        <a href="#about">About</a>
+        <a href="#contact">Contact</a>
+      </div>
+    </footer>
+
+  </body>
+</html>
+
+<style>
+  /* ── Reset / base ───────────────────────────────────────────── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: var(--da-font);
+    background: var(--da-bg);
+    color: var(--da-ink);
+    font-size: var(--da-body);
+    line-height: var(--da-lead-body);
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  a { color: inherit; text-decoration: none; }
+  a:focus-visible {
+    outline: 2px solid var(--da-accent);
+    outline-offset: 3px;
+    border-radius: var(--da-r);
+  }
+
+  /* ── Label (eyebrow) ─────────────────────────────────────────── */
+  .label {
+    font-size: var(--da-label);
+    font-weight: 600;
+    letter-spacing: var(--da-track-label);
+    text-transform: uppercase;
+    color: var(--da-ink-muted);
+    margin-bottom: 14px;
+  }
+
+  /* ── Buttons ─────────────────────────────────────────────────── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 22px;
+    border-radius: 999px;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    transition: background 0.18s var(--da-ease), color 0.18s var(--da-ease), border-color 0.18s var(--da-ease);
+  }
+  .btn--primary {
+    background: var(--da-ink);
+    color: #fff;
+    border: 1.5px solid var(--da-ink);
+  }
+  .btn--primary:hover {
+    background: var(--da-accent);
+    border-color: var(--da-accent);
+  }
+  .btn--ghost {
+    background: transparent;
+    color: var(--da-ink);
+    border: 1.5px solid var(--da-line-mid);
+  }
+  .btn--ghost:hover { border-color: var(--da-ink); }
+  .btn--lg { padding: 16px 28px; font-size: 16px; }
+
+  /* ── Nav ─────────────────────────────────────────────────────── */
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px clamp(20px, 5vw, 80px);
+    border-bottom: 1px solid var(--da-line);
+    background: rgba(250, 250, 248, 0.92);
+    backdrop-filter: blur(12px);
+  }
+  .nav__brand {
+    font-size: 16px;
+    font-weight: 800;
+    letter-spacing: var(--da-track-tight);
+  }
+  .nav__links {
+    display: flex;
+    align-items: center;
+    gap: 28px;
+    font-size: 14px;
+  }
+  .nav__links a { color: var(--da-ink-muted); transition: color 0.15s; }
+  .nav__links a:hover { color: var(--da-ink); }
+  .nav__cta {
+    padding: 10px 18px;
+    border: 1.5px solid var(--da-line-mid);
+    border-radius: 999px;
+    color: var(--da-ink) !important;
+    transition: border-color 0.15s, background 0.15s !important;
+  }
+  .nav__cta:hover { border-color: var(--da-ink) !important; background: var(--da-accent-dim); }
+
+  /* ── Section base ────────────────────────────────────────────── */
+  .section {
+    padding: var(--da-section) clamp(20px, 5vw, 80px);
+    border-top: 1px solid var(--da-line);
+  }
+  .section:first-of-type { border-top: none; }
+  .section__header { margin-bottom: var(--da-gap); }
+  .section__header h2 {
+    font-size: var(--da-h2);
+    font-weight: 700;
+    letter-spacing: var(--da-track-head);
+    line-height: 1.1;
+  }
+
+  /* ── Hero ────────────────────────────────────────────────────── */
+  .hero { border-top: none; }
+  .hero__h1 {
+    font-size: var(--da-display);
+    font-weight: 700;
+    letter-spacing: var(--da-track-tight);
+    line-height: var(--da-lead-tight);
+    margin-bottom: 28px;
+    max-width: 18ch;
+  }
+  .hero__sub {
+    font-size: var(--da-body-lg);
+    max-width: 56ch;
+    color: var(--da-ink-muted);
+    margin-bottom: 36px;
+    line-height: 1.6;
+  }
+  .hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: var(--da-gap);
+  }
+
+  /* Proof ribbon */
+  .proof {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+    border-top: 1px solid var(--da-line);
+    padding-top: 36px;
+    margin-top: 8px;
+  }
+  .proof__item { padding-right: 24px; }
+  .proof__num {
+    display: block;
+    font-size: clamp(28px, 3.5vw, 40px);
+    font-weight: 800;
+    letter-spacing: var(--da-track-tight);
+    color: var(--da-accent);
+    line-height: 1;
+    margin-bottom: 6px;
+  }
+  .proof__text {
+    font-size: 13px;
+    color: var(--da-ink-muted);
+    line-height: 1.4;
+  }
+  .proof__div {
+    width: 1px;
+    background: var(--da-line);
+    margin: 0 24px 0 0;
+    align-self: stretch;
+  }
+
+  /* ── Services ────────────────────────────────────────────────── */
+  .services__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0;
+  }
+  .svc {
+    padding: 36px 32px 36px 0;
+    border-right: 1px solid var(--da-line);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .svc:last-child { border-right: 0; padding-right: 0; }
+  .svc:not(:first-child) { padding-left: 32px; }
+  .svc__num {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    color: var(--da-ink-faint);
+    margin-bottom: 4px;
+  }
+  .svc__title {
+    font-size: var(--da-h3);
+    font-weight: 700;
+    letter-spacing: var(--da-track-head);
+    line-height: 1.25;
+  }
+  .svc__body {
+    font-size: 14px;
+    color: var(--da-ink-muted);
+    line-height: 1.6;
+    flex: 1;
+  }
+  .svc__link {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--da-accent);
+    margin-top: 4px;
+    transition: opacity 0.15s;
+  }
+  .svc__link:hover { opacity: 0.7; }
+
+  /* ── How ─────────────────────────────────────────────────────── */
+  .how__steps {
+    display: flex;
+    align-items: flex-start;
+    gap: 0;
+  }
+  .step {
+    flex: 1;
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+  }
+  .step__n {
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1.5px solid var(--da-line-mid);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+  .step__t {
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+  .step__b { font-size: 14px; color: var(--da-ink-muted); line-height: 1.55; }
+  .step__arrow {
+    font-size: 20px;
+    color: var(--da-ink-faint);
+    padding: 4px 20px 0;
+    flex-shrink: 0;
+  }
+
+  /* ── About ───────────────────────────────────────────────────── */
+  .about { background: var(--da-surface); }
+  .about__inner {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--da-gap);
+  }
+  .about__left h2 {
+    font-size: var(--da-h2);
+    font-weight: 700;
+    letter-spacing: var(--da-track-head);
+    line-height: 1.1;
+    margin-bottom: 20px;
+  }
+  .about__left p {
+    font-size: 15px;
+    color: var(--da-ink-muted);
+    max-width: 44ch;
+    margin-bottom: 14px;
+    line-height: 1.65;
+  }
+  .credential__label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--da-ink-faint);
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--da-line);
+  }
+  .credential__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .credential__list li {
+    font-size: 14px;
+    color: var(--da-ink-muted);
+    padding: 8px 0;
+    border-bottom: 1px solid var(--da-line);
+    line-height: 1.4;
+  }
+
+  /* ── Contact ─────────────────────────────────────────────────── */
+  .contact { background: var(--da-ink); }
+  .contact .label { color: rgba(255,255,255,0.5); }
+  .contact__inner h2 {
+    font-size: var(--da-h2);
+    font-weight: 700;
+    letter-spacing: var(--da-track-head);
+    line-height: 1.1;
+    color: #fff;
+    margin-bottom: 16px;
+  }
+  .contact__sub {
+    font-size: var(--da-body);
+    color: rgba(255,255,255,0.65);
+    max-width: 50ch;
+    margin-bottom: 28px;
+    line-height: 1.6;
+  }
+  .contact .btn--primary {
+    background: var(--da-accent);
+    border-color: var(--da-accent);
+    font-size: 16px;
+  }
+  .contact .btn--primary:hover { background: #25585B; border-color: #25585B; }
+  .contact__note {
+    margin-top: 14px;
+    font-size: 13px;
+    color: rgba(255,255,255,0.4);
+  }
+
+  /* ── Footer ──────────────────────────────────────────────────── */
+  .footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px clamp(20px, 5vw, 80px);
+    border-top: 1px solid rgba(255,255,255,0.10);
+    background: var(--da-ink);
+  }
+  .footer__brand {
+    font-size: 15px;
+    font-weight: 800;
+    letter-spacing: var(--da-track-tight);
+    color: #fff;
+    margin-right: 16px;
+  }
+  .footer__tag { font-size: 12px; color: rgba(255,255,255,0.35); }
+  .footer__left { display: flex; align-items: center; gap: 16px; }
+  .footer__right { display: flex; gap: 20px; font-size: 13px; color: rgba(255,255,255,0.45); }
+  .footer__right a:hover { color: rgba(255,255,255,0.75); }
+
+  /* ── Responsive ──────────────────────────────────────────────── */
+  @media (max-width: 900px) {
+    .proof { grid-template-columns: 1fr 1fr; gap: 24px; }
+    .proof__div { display: none; }
+    .services__grid { grid-template-columns: 1fr; }
+    .svc { border-right: 0; border-bottom: 1px solid var(--da-line); padding: 28px 0; }
+    .svc:last-child { border-bottom: 0; }
+    .svc:not(:first-child) { padding-left: 0; }
+    .how__steps { flex-direction: column; gap: 24px; }
+    .step__arrow { display: none; }
+    .about__inner { grid-template-columns: 1fr; }
+    .footer { flex-direction: column; gap: 16px; text-align: center; }
+  }
+  @media (max-width: 480px) {
+    .proof { grid-template-columns: 1fr 1fr; }
+    .nav__links a:not(.nav__cta) { display: none; }
+  }
+</style>

--- a/src/styles/tokens-deep-a.css
+++ b/src/styles/tokens-deep-a.css
@@ -1,0 +1,54 @@
+/**
+ * Concept A Deep — "Modern Consulting"
+ * Palette A (teal accent) × MetaLab/barvere art direction.
+ *
+ * Design principles:
+ * - Typography does the heavy lifting. Scale is aggressive, tracking tight.
+ * - White canvas. No shadows. Hairline lines, not box borders.
+ * - Teal accent used ONCE per fold for maximum signal strength.
+ * - Extreme whitespace between sections (sections breathe).
+ * - Grid = implicit. No heavy card chrome.
+ */
+
+:root {
+  /* Canvas */
+  --da-bg:        #FAFAF8;
+  --da-surface:   #FFFFFF;
+  --da-ink:       #111210;
+  --da-ink-muted: rgba(17, 18, 16, 0.55);
+  --da-ink-faint: rgba(17, 18, 16, 0.22);
+  --da-line:      rgba(17, 18, 16, 0.10);
+  --da-line-mid:  rgba(17, 18, 16, 0.18);
+
+  /* Accent — used sparingly */
+  --da-accent:     #2F6F73;
+  --da-accent-dim: rgba(47, 111, 115, 0.12);
+
+  /* Type scale */
+  --da-font:        -apple-system, BlinkMacSystemFont, 'Inter', 'Helvetica Neue', Arial, sans-serif;
+
+  --da-display:     clamp(52px, 8vw, 96px);   /* Hero H1 */
+  --da-h2:          clamp(32px, 4vw, 48px);   /* Section heads */
+  --da-h3:          18px;                      /* Pillar titles */
+  --da-body-lg:     18px;
+  --da-body:        16px;
+  --da-label:       12px;
+
+  --da-track-tight: -0.04em;
+  --da-track-head:  -0.02em;
+  --da-track-label: 0.12em;
+
+  --da-lead-tight:  1.05;
+  --da-lead-body:   1.65;
+
+  /* Spacing rhythm */
+  --da-section: clamp(80px, 10vw, 128px);
+  --da-gap:     clamp(40px, 5vw, 64px);
+
+  /* Radius (sharp, editorial) */
+  --da-r-sm: 2px;
+  --da-r:    6px;
+
+  /* Transitions */
+  --da-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}


### PR DESCRIPTION
Adds a deep art-directed Concept A homepage at `/concept-a/`, inspired by MetaLab and barvere.co.za.

Design decisions:
- Oversized display type (96px, tight -0.04em tracking)
- Proof ribbon immediately below the hero (4 anonymised metrics)
- Services as hairline-divided columns — no card chrome
- Process steps with numbered circles + arrows
- Dark contact section for high contrast
- Zero box shadows. Hairlines only.
- Teal accent used once per fold (proof numbers, enquire links, CTA)
