### PR TITLE
fix: broken contact links + motion polish & count-up (#23, #24)

### DIFF
--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -166,6 +166,83 @@ const currentPath = Astro.url.pathname;
       })();
     </script>
 
+    <!-- COUNT-UP ────────────────────────────────────────────────── -->
+    <script is:inline>
+      (function () {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+        var countEls = document.querySelectorAll('.proof__num, .bio-stat__num');
+        if (!countEls.length) return;
+
+        // Parse a stat element into { node, prefix, value, suffix, originalText }
+        // Handles formats: "10", "13×", "+50%", "R320m" and nested spans (e.g. "20<span>+</span>")
+        function parseCountEl(el) {
+          // Find first direct text node (skips child elements like .bio-stat__plus)
+          var textNode = null;
+          for (var i = 0; i < el.childNodes.length; i++) {
+            if (el.childNodes[i].nodeType === 3 && el.childNodes[i].textContent.trim()) {
+              textNode = el.childNodes[i];
+              break;
+            }
+          }
+          var raw = textNode ? textNode.textContent.trim() : el.textContent.trim();
+          var m = raw.match(/^([+R]?)(\d+(?:\.\d+)?)([×%m]?)$/);
+          if (!m || parseFloat(m[2]) === 0) return null;
+          return {
+            node: textNode,
+            el: el,
+            prefix: m[1],
+            value: parseFloat(m[2]),
+            suffix: m[3],
+            originalText: raw,
+          };
+        }
+
+        function easeOutCubic(t) { return 1 - Math.pow(1 - t, 3); }
+
+        function animateCount(parsed) {
+          if (!parsed) return;
+          var duration = 1400;
+          var start = performance.now();
+          function frame(now) {
+            var progress = Math.min((now - start) / duration, 1);
+            var current = Math.round(easeOutCubic(progress) * parsed.value);
+            var text = parsed.prefix + current + parsed.suffix;
+            if (parsed.node) {
+              parsed.node.textContent = text;
+            } else {
+              parsed.el.textContent = text;
+            }
+            if (progress < 1) {
+              requestAnimationFrame(frame);
+            } else {
+              // Restore exact original (handles any rounding edge cases)
+              if (parsed.node) {
+                parsed.node.textContent = parsed.originalText;
+              } else {
+                parsed.el.textContent = parsed.originalText;
+              }
+            }
+          }
+          requestAnimationFrame(frame);
+        }
+
+        var countObserver = new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (entry) {
+              if (entry.isIntersecting) {
+                animateCount(parseCountEl(entry.target));
+                countObserver.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.5 }
+        );
+
+        countEls.forEach(function (el) { countObserver.observe(el); });
+      })();
+    </script>
+
   </body>
 </html>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,6 +4,8 @@
  */
 import SiteLayout from '../layouts/SiteLayout.astro';
 
+const base = import.meta.env.BASE_URL;
+
 const experience = [
   {
     role: 'Independent Contractor — Digital Product &amp; Transformation',
@@ -185,7 +187,7 @@ const education = [
         Get in touch to discuss your product or transformation challenge.
         LeRoy responds within one to two business days.
       </p>
-      <a class="btn btn--accent btn--lg" href="contact/">Start a conversation →</a>
+      <a class="btn btn--accent btn--lg" href={`${base}contact/`}>Start a conversation →</a>
     </div>
   </section>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -7,6 +7,7 @@
 import SiteLayout from '../layouts/SiteLayout.astro';
 
 const BASIN_ENDPOINT = 'https://usebasin.com/f/f28bdade2111';
+const base = import.meta.env.BASE_URL;
 ---
 
 <SiteLayout
@@ -123,7 +124,7 @@ const BASIN_ENDPOINT = 'https://usebasin.com/f/f28bdade2111';
             Thanks for reaching out. LeRoy will be in touch within
             one to two business days.
           </p>
-          <a class="btn btn--ghost" href="contact/">Send another message</a>
+          <a class="btn btn--ghost" href={`${base}contact/`}>Send another message</a>
         </div>
       </div>
 
@@ -144,9 +145,9 @@ const BASIN_ENDPOINT = 'https://usebasin.com/f/f28bdade2111';
         <div class="sidebar-card sidebar-card--services">
           <div class="sidebar-card__label">Services</div>
           <ul class="sidebar-services">
-            <li><a href="services/#product-management">Product Management &amp; Strategy</a></li>
-            <li><a href="services/#digital-transformation">Digital Transformation</a></li>
-            <li><a href="services/#banking-payments">Online Banking &amp; Digital Payments</a></li>
+            <li><a href={`${base}services/#product-management`}>Product Management &amp; Strategy</a></li>
+            <li><a href={`${base}services/#digital-transformation`}>Digital Transformation</a></li>
+            <li><a href={`${base}services/#banking-payments`}>Online Banking &amp; Digital Payments</a></li>
           </ul>
         </div>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,8 @@
  * Design: Concept A (clean light, teal accent)
  */
 import SiteLayout from '../layouts/SiteLayout.astro';
+
+const base = import.meta.env.BASE_URL;
 ---
 
 <SiteLayout
@@ -23,8 +25,8 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       payments, and insurance.
     </p>
     <div class="hero__actions" data-enter="3">
-      <a class="btn btn--primary" href="contact/">Get in touch</a>
-      <a class="btn btn--ghost" href="services/">See services →</a>
+      <a class="btn btn--primary" href={`${base}contact/`}>Get in touch</a>
+      <a class="btn btn--ghost" href={`${base}services/`}>See services →</a>
     </div>
 
     <!-- Proof ribbon -->
@@ -66,7 +68,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
           Roadmapping, OKRs, and prioritisation frameworks that align
           digital product teams with real business outcomes.
         </p>
-        <a class="svc__link" href="services/">Learn more →</a>
+        <a class="svc__link" href={`${base}services/`}>Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">02</div>
@@ -76,7 +78,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
           cross-functional operating model redesign — from quarterly to
           weekly release cycles.
         </p>
-        <a class="svc__link" href="services/">Learn more →</a>
+        <a class="svc__link" href={`${base}services/`}>Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">03</div>
@@ -86,7 +88,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
           payment gateway integrations, and fintech platforms across
           African markets.
         </p>
-        <a class="svc__link" href="services/">Learn more →</a>
+        <a class="svc__link" href={`${base}services/`}>Learn more →</a>
       </article>
     </div>
   </section>
@@ -140,7 +142,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
           He works directly with founders and executive teams.
           No account managers, no padding.
         </p>
-        <a class="btn btn--ghost" href="about/" style="margin-top: 24px;">About LeRoy →</a>
+        <a class="btn btn--ghost" href={`${base}about/`} style="margin-top: 24px;">About LeRoy →</a>
       </div>
       <div class="about-preview__right" data-reveal>
         <div class="credential">
@@ -174,7 +176,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
         Briefly describe what you're trying to achieve.
         LeRoy responds within one to two business days.
       </p>
-      <a class="btn btn--accent btn--lg" href="contact/">Start a conversation →</a>
+      <a class="btn btn--accent btn--lg" href={`${base}contact/`}>Start a conversation →</a>
     </div>
   </section>
 

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -3,6 +3,8 @@
  * Services — LBDC V1
  */
 import SiteLayout from '../layouts/SiteLayout.astro';
+
+const base = import.meta.env.BASE_URL;
 ---
 
 <SiteLayout
@@ -27,7 +29,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <div class="svc-detail__meta">
         <div class="svc-num">01</div>
         <h2 class="svc-detail__title">Product Management<br>&amp; Strategy</h2>
-        <a class="btn btn--primary" href="contact/">Enquire →</a>
+        <a class="btn btn--primary" href={`${base}contact/`}>Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -63,7 +65,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <div class="svc-detail__meta">
         <div class="svc-num">02</div>
         <h2 class="svc-detail__title">Digital<br>Transformation</h2>
-        <a class="btn btn--primary" href="contact/">Enquire →</a>
+        <a class="btn btn--primary" href={`${base}contact/`}>Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -100,7 +102,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <div class="svc-detail__meta">
         <div class="svc-num">03</div>
         <h2 class="svc-detail__title">Online Banking &amp;<br>Digital Payments</h2>
-        <a class="btn btn--primary" href="contact/">Enquire →</a>
+        <a class="btn btn--primary" href={`${base}contact/`}>Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -161,7 +163,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
         Every engagement starts with a conversation.
         No pitch, no deck — just a direct discussion about your challenge.
       </p>
-      <a class="btn btn--accent btn--lg" href="contact/">Get in touch →</a>
+      <a class="btn btn--accent btn--lg" href={`${base}contact/`}>Get in touch →</a>
     </div>
   </section>
 

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -19,13 +19,13 @@
  * Each step adds ~0.13 s to the delay.
  */
 [data-enter] {
-  animation: lbdc-fade-up 0.65s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)) both;
+  animation: lbdc-fade-up 0.80s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)) both;
 }
-[data-enter="0"] { animation-delay: 0.05s; }
-[data-enter="1"] { animation-delay: 0.18s; }
-[data-enter="2"] { animation-delay: 0.31s; }
-[data-enter="3"] { animation-delay: 0.46s; }
-[data-enter="4"] { animation-delay: 0.62s; }
+[data-enter="0"] { animation-delay: 0.08s; }
+[data-enter="1"] { animation-delay: 0.22s; }
+[data-enter="2"] { animation-delay: 0.38s; }
+[data-enter="3"] { animation-delay: 0.56s; }
+[data-enter="4"] { animation-delay: 0.76s; }
 
 /* ── Scroll reveal ──────────────────────────────────────────────── */
 /*
@@ -36,18 +36,18 @@
   opacity: 0;
   transform: translateY(16px);
   transition:
-    opacity 0.55s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)),
-    transform 0.55s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1));
+    opacity 0.70s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)),
+    transform 0.70s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1));
 }
 [data-reveal].is-visible {
   opacity: 1;
   transform: translateY(0);
 }
 /* Sibling stagger — works when multiple [data-reveal] share a parent */
-[data-reveal]:nth-child(2) { transition-delay: 0.09s; }
-[data-reveal]:nth-child(3) { transition-delay: 0.18s; }
-[data-reveal]:nth-child(4) { transition-delay: 0.27s; }
-[data-reveal]:nth-child(5) { transition-delay: 0.36s; }
+[data-reveal]:nth-child(2) { transition-delay: 0.12s; }
+[data-reveal]:nth-child(3) { transition-delay: 0.24s; }
+[data-reveal]:nth-child(4) { transition-delay: 0.36s; }
+[data-reveal]:nth-child(5) { transition-delay: 0.48s; }
 
 /* ── Button micro-interactions ──────────────────────────────────── */
 /*


### PR DESCRIPTION
Closes #23, closes #24.

Branched from `feat/motion-issue-21` (includes the #21 motion foundation).

## #23 — Broken contact links

**Root cause:** Page CTAs and sidebar links used bare relative hrefs like `href="contact/"`. From any sub-page (`/services/`, `/about/`, `/contact/`), the browser resolves these relative to the current path → `/lbdc-website/services/contact/` — not found on GitHub Pages.

**Fix:** Added `const base = import.meta.env.BASE_URL;` to the frontmatter of `index.astro`, `services.astro`, `about.astro`, and `contact.astro`. All inline CTA and sidebar links now use `` href={`${base}contact/`} `` etc., which always resolves to `/lbdc-website/contact/` regardless of the current page. The nav/footer in `SiteLayout.astro` were already correct.

**How to test:**
1. `npm run build && npm run preview`
2. Go to `/lbdc-website/services/` → click "Enquire →" → should land on `/lbdc-website/contact/` ✓
3. Go to `/lbdc-website/about/` → click "Start a conversation →" → `/lbdc-website/contact/` ✓
4. On `/lbdc-website/contact/`, the sidebar "Services" links should jump to `/lbdc-website/services/#...` ✓

---

## #24 — Motion polish + count-up

### Slower, more premium motion (`src/styles/motion.css`)

| | Before | After |
|---|---|---|
| Hero entrance duration | 0.65s | **0.80s** |
| Hero stagger delays | 0.05 / 0.18 / 0.31 / 0.46 / 0.62s | **0.08 / 0.22 / 0.38 / 0.56 / 0.76s** |
| Scroll reveal duration | 0.55s | **0.70s** |
| Scroll reveal stagger | 0.09 / 0.18 / 0.27 / 0.36s | **0.12 / 0.24 / 0.36 / 0.48s** |

Button/nav micro-interactions unchanged — they should stay snappy.

### Count-up animation (`src/layouts/SiteLayout.astro`)

New `is:inline` script. When `.proof__num` or `.bio-stat__num` elements scroll 50% into view, they count from 0 to their target over 1.4s (easeOutCubic), once only.

Handled formats: `10`, `13×`, `+50%`, `R320m`, `20` (with nested `+` span kept intact — only the text node is animated, no layout shift).

`prefers-reduced-motion: reduce` → script exits immediately; numbers show at final value with no animation.

**How to test:**
1. Home page → scroll to the proof ribbon → `10`, `13×`, `+50%`, `R320m` count up on enter
2. About page → scroll to bio aside → `20+`, `10`, `13×` count up
3. DevTools → Rendering → "Emulate prefers-reduced-motion: reduce" → numbers appear instantly at final value

🤖 Generated with [Claude Code](https://claude.com/claude-code)