### PR TITLE
fix: home/about/services/contact links (base join)

### DIFF
--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -24,12 +24,21 @@ const {
   bareNav = false,
 } = Astro.props;
 
+// NOTE: Astro's BASE_URL may or may not include a trailing slash depending on
+// build config / environment. Always join paths safely so we don't end up with
+// broken links like "/lbdc-websitecontact/".
 const base = import.meta.env.BASE_URL;
 
+const withBase = (path: string) => {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = path.replace(/^\//, '');
+  return `${b}${p}`;
+};
+
 const navLinks = [
-  { href: `${base}services/`, label: 'Services' },
-  { href: `${base}about/`,    label: 'About' },
-  { href: `${base}contact/`,  label: 'Contact' },
+  { href: withBase('services/'), label: 'Services' },
+  { href: withBase('about/'),    label: 'About' },
+  { href: withBase('contact/'),  label: 'Contact' },
 ];
 
 const currentPath = Astro.url.pathname;
@@ -45,8 +54,8 @@ const currentPath = Astro.url.pathname;
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
-    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
-    <link rel="icon" href={`${base}favicon.ico`} />
+    <link rel="icon" type="image/svg+xml" href={withBase('favicon.svg')} />
+    <link rel="icon" href={withBase('favicon.ico')} />
     <title>{title} — LBDC</title>
 
     {/* Palette init: runs before first paint to avoid flash */}
@@ -66,7 +75,7 @@ const currentPath = Astro.url.pathname;
     <!-- NAV ─────────────────────────────────────────────────────── -->
     {!bareNav && (
       <nav class="nav">
-        <a class="nav__brand" href={base} aria-label="LBDC — home">LBDC</a>
+        <a class="nav__brand" href={withBase('')} aria-label="LBDC — home">LBDC</a>
         <div class="nav__links">
           {navLinks.map(({ href, label }) => (
             <a
@@ -76,7 +85,7 @@ const currentPath = Astro.url.pathname;
               {label}
             </a>
           ))}
-          <a class="nav__cta" href={`${base}contact/`}>Get in touch</a>
+          <a class="nav__cta" href={withBase('contact/')}>Get in touch</a>
         </div>
       </nav>
     )}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,6 +5,11 @@
 import SiteLayout from '../layouts/SiteLayout.astro';
 
 const base = import.meta.env.BASE_URL;
+const withBase = (path) => {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = String(path || '').replace(/^\//, '');
+  return `${b}${p}`;
+};
 
 const experience = [
   {
@@ -187,7 +192,7 @@ const education = [
         Get in touch to discuss your product or transformation challenge.
         LeRoy responds within one to two business days.
       </p>
-      <a class="btn btn--accent btn--lg" href={`${base}contact/`}>Start a conversation →</a>
+      <a class="btn btn--accent btn--lg" href={withBase('contact/')}>Start a conversation →</a>
     </div>
   </section>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,6 +8,11 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 
 const BASIN_ENDPOINT = 'https://usebasin.com/f/f28bdade2111';
 const base = import.meta.env.BASE_URL;
+const withBase = (path) => {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = String(path || '').replace(/^\//, '');
+  return `${b}${p}`;
+};
 ---
 
 <SiteLayout
@@ -124,7 +129,7 @@ const base = import.meta.env.BASE_URL;
             Thanks for reaching out. LeRoy will be in touch within
             one to two business days.
           </p>
-          <a class="btn btn--ghost" href={`${base}contact/`}>Send another message</a>
+          <a class="btn btn--ghost" href={withBase('contact/')}>Send another message</a>
         </div>
       </div>
 
@@ -145,9 +150,9 @@ const base = import.meta.env.BASE_URL;
         <div class="sidebar-card sidebar-card--services">
           <div class="sidebar-card__label">Services</div>
           <ul class="sidebar-services">
-            <li><a href={`${base}services/#product-management`}>Product Management &amp; Strategy</a></li>
-            <li><a href={`${base}services/#digital-transformation`}>Digital Transformation</a></li>
-            <li><a href={`${base}services/#banking-payments`}>Online Banking &amp; Digital Payments</a></li>
+            <li><a href={withBase('services/#product-management')}>Product Management &amp; Strategy</a></li>
+            <li><a href={withBase('services/#digital-transformation')}>Digital Transformation</a></li>
+            <li><a href={withBase('services/#banking-payments')}>Online Banking &amp; Digital Payments</a></li>
           </ul>
         </div>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,11 @@
 import SiteLayout from '../layouts/SiteLayout.astro';
 
 const base = import.meta.env.BASE_URL;
+const withBase = (path) => {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = String(path || '').replace(/^\//, '');
+  return `${b}${p}`;
+};
 ---
 
 <SiteLayout
@@ -25,8 +30,8 @@ const base = import.meta.env.BASE_URL;
       payments, and insurance.
     </p>
     <div class="hero__actions" data-enter="3">
-      <a class="btn btn--primary" href={`${base}contact/`}>Get in touch</a>
-      <a class="btn btn--ghost" href={`${base}services/`}>See services →</a>
+      <a class="btn btn--primary" href={withBase('contact/')}>Get in touch</a>
+      <a class="btn btn--ghost" href={withBase('services/')}>See services →</a>
     </div>
 
     <!-- Proof ribbon -->
@@ -176,7 +181,7 @@ const base = import.meta.env.BASE_URL;
         Briefly describe what you're trying to achieve.
         LeRoy responds within one to two business days.
       </p>
-      <a class="btn btn--accent btn--lg" href={`${base}contact/`}>Start a conversation →</a>
+      <a class="btn btn--accent btn--lg" href={withBase('contact/')}>Start a conversation →</a>
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -73,7 +73,7 @@ const withBase = (path) => {
           Roadmapping, OKRs, and prioritisation frameworks that align
           digital product teams with real business outcomes.
         </p>
-        <a class="svc__link" href={`${base}services/`}>Learn more →</a>
+        <a class="svc__link" href={withBase('services/')}>Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">02</div>
@@ -83,7 +83,7 @@ const withBase = (path) => {
           cross-functional operating model redesign — from quarterly to
           weekly release cycles.
         </p>
-        <a class="svc__link" href={`${base}services/`}>Learn more →</a>
+        <a class="svc__link" href={withBase('services/')}>Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">03</div>
@@ -93,7 +93,7 @@ const withBase = (path) => {
           payment gateway integrations, and fintech platforms across
           African markets.
         </p>
-        <a class="svc__link" href={`${base}services/`}>Learn more →</a>
+        <a class="svc__link" href={withBase('services/')}>Learn more →</a>
       </article>
     </div>
   </section>
@@ -147,7 +147,7 @@ const withBase = (path) => {
           He works directly with founders and executive teams.
           No account managers, no padding.
         </p>
-        <a class="btn btn--ghost" href={`${base}about/`} style="margin-top: 24px;">About LeRoy →</a>
+        <a class="btn btn--ghost" href={withBase('about/')} style="margin-top: 24px;">About LeRoy →</a>
       </div>
       <div class="about-preview__right" data-reveal>
         <div class="credential">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -5,6 +5,11 @@
 import SiteLayout from '../layouts/SiteLayout.astro';
 
 const base = import.meta.env.BASE_URL;
+const withBase = (path) => {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = String(path || '').replace(/^\//, '');
+  return `${b}${p}`;
+};
 ---
 
 <SiteLayout
@@ -29,7 +34,7 @@ const base = import.meta.env.BASE_URL;
       <div class="svc-detail__meta">
         <div class="svc-num">01</div>
         <h2 class="svc-detail__title">Product Management<br>&amp; Strategy</h2>
-        <a class="btn btn--primary" href={`${base}contact/`}>Enquire →</a>
+        <a class="btn btn--primary" href={withBase('contact/')}>Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -65,7 +70,7 @@ const base = import.meta.env.BASE_URL;
       <div class="svc-detail__meta">
         <div class="svc-num">02</div>
         <h2 class="svc-detail__title">Digital<br>Transformation</h2>
-        <a class="btn btn--primary" href={`${base}contact/`}>Enquire →</a>
+        <a class="btn btn--primary" href={withBase('contact/')}>Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -102,7 +107,7 @@ const base = import.meta.env.BASE_URL;
       <div class="svc-detail__meta">
         <div class="svc-num">03</div>
         <h2 class="svc-detail__title">Online Banking &amp;<br>Digital Payments</h2>
-        <a class="btn btn--primary" href={`${base}contact/`}>Enquire →</a>
+        <a class="btn btn--primary" href={withBase('contact/')}>Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -163,7 +168,7 @@ const base = import.meta.env.BASE_URL;
         Every engagement starts with a conversation.
         No pitch, no deck — just a direct discussion about your challenge.
       </p>
-      <a class="btn btn--accent btn--lg" href={`${base}contact/`}>Get in touch →</a>
+      <a class="btn btn--accent btn--lg" href={withBase('contact/')}>Get in touch →</a>
     </div>
   </section>
 

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -19,13 +19,13 @@
  * Each step adds ~0.13 s to the delay.
  */
 [data-enter] {
-  animation: lbdc-fade-up 0.80s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)) both;
+  animation: lbdc-fade-up 1.05s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)) both;
 }
-[data-enter="0"] { animation-delay: 0.08s; }
-[data-enter="1"] { animation-delay: 0.22s; }
-[data-enter="2"] { animation-delay: 0.38s; }
-[data-enter="3"] { animation-delay: 0.56s; }
-[data-enter="4"] { animation-delay: 0.76s; }
+[data-enter="0"] { animation-delay: 0.12s; }
+[data-enter="1"] { animation-delay: 0.32s; }
+[data-enter="2"] { animation-delay: 0.54s; }
+[data-enter="3"] { animation-delay: 0.78s; }
+[data-enter="4"] { animation-delay: 1.04s; }
 
 /* ── Scroll reveal ──────────────────────────────────────────────── */
 /*
@@ -36,8 +36,8 @@
   opacity: 0;
   transform: translateY(16px);
   transition:
-    opacity 0.70s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)),
-    transform 0.70s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1));
+    opacity 0.92s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1)),
+    transform 0.92s var(--da-ease, cubic-bezier(0.16, 1, 0.3, 1));
 }
 [data-reveal].is-visible {
   opacity: 1;


### PR DESCRIPTION
## Why
- Contact CTAs were still resolving incorrectly on GitHub Pages because `BASE_URL` did not always include a trailing slash (producing `/lbdc-websitecontact/`).
- Motion still feels a bit rushed; this slows timings to a calmer pace.

## What changed
- Added a small `withBase()` helper (safe path join) in `SiteLayout` and each page that has its own CTA links.
- Replaced `${base}contact/` style links with `withBase('contact/')` so links always resolve to `/lbdc-website/contact/`.
- Slowed hero + reveal timings in `src/styles/motion.css`.

## How to test
- Visit About/Services/Home and click: **Get in touch / Contact / Start a conversation**.
- Confirm all route to: `https://skippies-io.github.io/lbdc-website/contact/`
- Motion: refresh Home and scroll; animations should feel calmer.

Closes #23
