### PR TITLE
privacy: avoid public email scraping (hello@ + reveal)

### DIFF
--- a/src/pages/concept-a/index.astro
+++ b/src/pages/concept-a/index.astro
@@ -184,8 +184,8 @@ import '../../styles/tokens-deep-a.css';
           Briefly describe what you're trying to achieve.
           LeRoy responds within one to two business days.
         </p>
-        <a class="btn btn--primary btn--lg" href="mailto:leroy@lbdc.co.za">leroy@lbdc.co.za →</a>
-        <p class="contact__note">Or use the form below — coming soon.</p>
+        <a class="btn btn--primary btn--lg" href="../contact/">Get in touch →</a>
+        <p class="contact__note">Prefer email? Use hello@lbdc.co.za</p>
       </div>
     </section>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -137,7 +137,10 @@ const withBase = (path) => {
       <div class="contact-sidebar" data-reveal>
         <div class="sidebar-card">
           <div class="sidebar-card__label">Direct email</div>
-          <a class="sidebar-card__value" href="mailto:leroy@lbdc.co.za">leroy@lbdc.co.za</a>
+          <!-- Avoid publishing a clickable mailto to reduce scraping; the form is the primary contact route. -->
+          <div class="sidebar-card__value" id="direct-email" data-email-user="hello" data-email-domain="lbdc.co.za">
+            <button class="email-reveal" type="button">Show email</button>
+          </div>
         </div>
         <div class="sidebar-card">
           <div class="sidebar-card__label">Response time</div>
@@ -185,6 +188,23 @@ const withBase = (path) => {
         btn.setAttribute('aria-label', 'Sending message…');
         btn.disabled = true;
       }
+    });
+  }
+
+  // Email reveal (reduces casual scraping; form remains primary)
+  const emailWrap = document.getElementById('direct-email');
+  if (emailWrap) {
+    const btn = emailWrap.querySelector('.email-reveal');
+    btn?.addEventListener('click', () => {
+      const user = emailWrap.getAttribute('data-email-user');
+      const domain = emailWrap.getAttribute('data-email-domain');
+      if (!user || !domain) return;
+      const addr = `${user}@${domain}`;
+      const a = document.createElement('a');
+      a.className = 'email-link';
+      a.href = `mailto:${addr}`;
+      a.textContent = addr;
+      emailWrap.replaceChildren(a);
     });
   }
 </script>
@@ -326,6 +346,20 @@ const withBase = (path) => {
     color: var(--da-ink);
     word-break: break-all;
   }
+
+  /* Email reveal button (avoid default button chrome) */
+  .email-reveal {
+    appearance: none;
+    border: 1.5px solid var(--da-line-mid);
+    background: transparent;
+    color: var(--da-ink);
+    padding: 8px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .email-reveal:hover { border-color: var(--da-ink); }
+
   a.sidebar-card__value { color: var(--da-accent); }
   a.sidebar-card__value:hover { opacity: 0.75; }
   .sidebar-services {


### PR DESCRIPTION
## Recommendation
Best practice is **not** to publish a direct, clickable email address on a public site (it will get scraped). The contact form should be the primary channel.

If an email must be available, we can:
- use a generic address: **hello@lbdc.co.za**
- avoid a permanent `mailto:` link in the HTML
- reveal it on click (reduces casual scraping; not perfect against headless JS crawlers)

## What changed
- Contact page sidebar now shows a **“Show email”** button that reveals `hello@lbdc.co.za` on click.
- Removed the old `leroy@lbdc.co.za` address.
- Updated the legacy Concept A preview page to point to the Contact page (and references hello@).

## How to test
- Go to /contact/ and click **Show email**.
- Confirm the form still submits via Basin.

Closes: (none)
