### PR TITLE
privacy: remove public email (form-only contact)

### DIFF
--- a/src/pages/concept-a/index.astro
+++ b/src/pages/concept-a/index.astro
@@ -184,8 +184,8 @@ import '../../styles/tokens-deep-a.css';
           Briefly describe what you're trying to achieve.
           LeRoy responds within one to two business days.
         </p>
-        <a class="btn btn--primary btn--lg" href="mailto:leroy@lbdc.co.za">leroy@lbdc.co.za →</a>
-        <p class="contact__note">Or use the form below — coming soon.</p>
+        <a class="btn btn--primary btn--lg" href="#contact">Use the contact form →</a>
+        <p class="contact__note">(Email is intentionally not published to reduce spam.)</p>
       </div>
     </section>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -136,10 +136,6 @@ const withBase = (path) => {
       <!-- SIDEBAR ──────────────────────────────────────────────── -->
       <div class="contact-sidebar" data-reveal>
         <div class="sidebar-card">
-          <div class="sidebar-card__label">Direct email</div>
-          <a class="sidebar-card__value" href="mailto:leroy@lbdc.co.za">leroy@lbdc.co.za</a>
-        </div>
-        <div class="sidebar-card">
           <div class="sidebar-card__label">Response time</div>
           <div class="sidebar-card__value">1 – 2 business days</div>
         </div>


### PR DESCRIPTION
## Summary
Removes the publicly visible email address from the Contact page so all enquiries go via the contact form.

## Why
Publishing an email address on a public site is likely to be scraped and used by spammers.

## What changed
- Removed the "Direct email" card from `/contact/`.
- Updated the legacy Concept A preview page to avoid publishing a `mailto:` address.

## How to test
- Visit /contact/ and confirm no email is visible.
- Submit the contact form and confirm you get the success state.
