### PR TITLE
SEO: add canonical URLs

### DIFF
--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -55,6 +55,7 @@ const currentPath = Astro.url.pathname;
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
+    <link rel="canonical" href={`${Astro.site}${Astro.url.pathname}`} />
     <!-- Favicons -->
     <link rel="icon" type="image/png" sizes="32x32" href={withBase('favicon/favicon-32.png')} />
     <link rel="icon" type="image/png" sizes="16x16" href={withBase('favicon/favicon-16.png')} />


### PR DESCRIPTION
Adds canonical URL tags using Astro.site + Astro.url.pathname. Page titles/descriptions are already unique per page via SiteLayout props.\n\nCloses #34.\n\nTest: pnpm -s build