### PR TITLE
fix(contact): back button 404 after form submit

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -17,6 +17,8 @@ const withBase = (path) => {
 
 // Basin requires an absolute redirect URL.
 // This uses Astro.site (astro.config.mjs) so it will track the domain when we cut over.
+// Note: we intentionally avoid manipulating history entries after redirect so the
+// browser back button behaves predictably.
 const redirectUrl = `${Astro.site}${withBase('contact/?success=1')}`;
 ---
 
@@ -178,8 +180,6 @@ const redirectUrl = `${Astro.site}${withBase('contact/?success=1')}`;
     const success = document.getElementById('form-success');
     if (form) form.hidden = true;
     if (success) success.hidden = false;
-    // Clean URL without reload
-    history.replaceState(null, '', location.pathname);
   }
 
   // Client-side validation UX + loading state


### PR DESCRIPTION
Fixes browser back navigation after submitting the Basin contact form on GitHub Pages.

What changed:
- Stop rewriting history on the success redirect (removes history.replaceState).

How to test:
1) Open /contact
2) Submit the form
3) Press browser Back — should return to /contact (not skippies-io.github.io root / 404)

Build: pnpm run build