### PR TITLE
Release: wire GA4 analytics

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,6 +16,8 @@ const {
   title = 'LBDC',
   description = 'Product management and digital transformation consulting — online banking, payments, and pan-African fintech.',
 } = Astro.props;
+
+const GA_MEASUREMENT_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID ?? 'G-20KBH2YJCT';
 ---
 
 <!doctype html>
@@ -31,6 +33,21 @@ const {
     <meta property="og:type" content="website" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" href="/favicon.ico" />
+
+    {
+      import.meta.env.PROD && GA_MEASUREMENT_ID && (
+        <>
+          <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
+          <script is:inline>
+            {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_MEASUREMENT_ID}');`}
+          </script>
+        </>
+      )
+    }
+
     <title>{title}</title>
   </head>
   <body>


### PR DESCRIPTION
Implements GA4 tracking by injecting the gtag snippet in BaseLayout (production only).\n\n- Measurement ID: G-20KBH2YJCT (can be overridden via PUBLIC_GA_MEASUREMENT_ID)\n\nHow to test:\n- pnpm build\n- Deploy/preview and confirm GA4 Realtime shows an active user when visiting the site\n\nRisk: low\n\nCloses #42