### PR TITLE
Fix: custom domain asset paths

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,5 +3,5 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://skippies-io.github.io',
-  base: '/lbdc-website',});
+  site: 'https://www.lbdc.co.za',
+});


### PR DESCRIPTION
Fixes broken styling on custom domain by removing the GitHub project Pages base path (/lbdc-website) and setting site to https://www.lbdc.co.za.

How to test:
- pnpm build
- After deploy, visit https://www.lbdc.co.za and confirm CSS loads + navigation links don't include /lbdc-website

Risk: low

Fixes #40 follow-up work depends on this being correct.