### PR TITLE
refactor: migrate blog to Astro Content Collections

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,15 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    author: z.string(),
+    date: z.coerce.date(),
+    slug: z.string().optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/you-dont-need-to-code-you-need-to-think.md
+++ b/src/content/blog/you-dont-need-to-code-you-need-to-think.md
@@ -1,0 +1,37 @@
+---
+title: "You don't need to code. You need to think."
+description: "AI hasn't just made coding easier — it's democratised the ability to bend machines to your will. A reflection by LeRoy Barnes."
+author: LeRoy Barnes
+date: 2026-06-13
+slug: you-dont-need-to-code-you-need-to-think
+---
+
+AI hasn't just made coding easier; it's democratised the most powerful skill in software: the ability to bend machines to your will.
+
+[Antony Muriithi](https://www.linkedin.com/in/antony-muriithi-b53915114/), a Nairobi-based software engineer working to make tech accessible to all, and I were once in a taxi on our way to his barber. I needed a haircut, and he offered to introduce me to the guy who makes him look fresh. As we made our way from Westlands to Royal African Barbers in the CBD, Antony told me he believed that everyone should learn Python. For him, Python was easy enough to learn and write scripts that can automate tasks to improve productivity, mine data for insights, or get applications to exchange data, like syncing your CRM with your project management tool.
+
+Think about what scripting actually is. It's the ability to tell a machine exactly what you want, in a language it understands, and have it do it repeatedly, reliably, without you having to be in the room.
+
+That skill has always been the great divider. Programmers had it. The rest of us had to ask nicely, wait for someone to build it, or work around it.
+
+Not anymore.
+
+I'm not a programmer. My background is business analysis, product management, and digital transformation. But over the last few months, I've built things I genuinely didn't think were possible for someone like me.
+
+A system that reads my emails, identifies what needs action, and reports to me every morning. An automated invoicing flow connected to my accounting software. A daily brief assembled from multiple services is delivered to my phone. Scripts that retry when they fail, log what they did, and alert me when something breaks.
+
+I didn't write a single line of code myself.
+
+What I did was think and experiment — sitting with a problem until I could describe it precisely, then working with AI to build it: iterating, testing, fixing, adjusting until it did exactly what I needed.
+
+Here's what surprised me, though: the more I did it, the more I started thinking differently.
+
+When you work with AI to solve real problems, you develop a kind of structured thinking that mirrors how machines process things. You stop saying "it would be nice if…" and start saying "given X input, I want Y output, under these conditions." You anticipate failure modes. You ask: What does done actually look like?
+
+That's not a programmer skill, it's a thinking skill. AI has made it accessible to anyone willing to play with it.
+
+The old gatekeeping skill was knowing how to write the code. The new power skill is knowing how to think the problem through.
+
+If you've been waiting for someone technical to build the things you need — stop waiting. The tools are there. The barrier is lower than you think.
+
+The only real question is: can you think clearly about what you want?

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,8 +1,17 @@
 ---
-/**
- * Blog post: You don't need to code. You need to think.
- */
+import { getCollection, render } from 'astro:content';
 import SiteLayout from '../../layouts/SiteLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({
+    params: { slug: post.data.slug ?? post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
 
 const base = import.meta.env.BASE_URL;
 const withBase = (path) => {
@@ -11,11 +20,8 @@ const withBase = (path) => {
   return `${b}${p}`;
 };
 
-const title = "You don't need to code. You need to think.";
-const description = "AI hasn't just made coding easier — it's democratised the ability to bend machines to your will. A reflection by LeRoy Barnes.";
-const author = 'LeRoy Barnes';
-const date = '13 June 2026';
-const slug = 'you-dont-need-to-code-you-need-to-think';
+const { title, description, author, date } = post.data;
+const formattedDate = date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
 ---
 
 <SiteLayout title={title} description={description}>
@@ -28,44 +34,14 @@ const slug = 'you-dont-need-to-code-you-need-to-think';
     <div class="post-hero__byline" data-enter="3">
       <span class="byline__author">{author}</span>
       <span class="byline__sep">—</span>
-      <span class="byline__date">{date}</span>
+      <span class="byline__date">{formattedDate}</span>
     </div>
   </section>
 
   <!-- ARTICLE BODY ──────────────────────────────────────────────── -->
   <article class="post-body section">
     <div class="prose" data-reveal>
-
-      <p>AI hasn't just made coding easier; it's democratised the most powerful skill in software: the ability to bend machines to your will.</p>
-
-      <p><a href="https://www.linkedin.com/in/antony-muriithi-b53915114" target="_blank" rel="noopener noreferrer">Antony Muriithi</a>, a Nairobi-based software engineer working to make tech accessible to all, and I were once in a taxi on our way to his barber. I needed a haircut, and he offered to introduce me to the guy who makes him look fresh. As we made our way from Westlands to Royal African Barbers in the CBD, Antony told me he believed that everyone should learn Python. For him, Python was easy enough to learn and write scripts that can automate tasks to improve productivity, mine data for insights, or get applications to exchange data, like syncing your CRM with your project management tool.</p>
-
-      <p>Think about what scripting actually is. It's the ability to tell a machine exactly what you want, in a language it understands, and have it do it repeatedly, reliably, without you having to be in the room.</p>
-
-      <p>That skill has always been the great divider. Programmers had it. The rest of us had to ask nicely, wait for someone to build it, or work around it.</p>
-
-      <p>Not anymore.</p>
-
-      <p>I'm not a programmer. My background is business analysis, product management, and digital transformation. But over the last few months, I've built things I genuinely didn't think were possible for someone like me.</p>
-
-      <p>A system that reads my emails, identifies what needs action, and reports to me every morning. An automated invoicing flow connected to my accounting software. A daily brief assembled from multiple services is delivered to my phone. Scripts that retry when they fail, log what they did, and alert me when something breaks.</p>
-
-      <p>I didn't write a single line of code myself.</p>
-
-      <p>What I did was think and experiment — sitting with a problem until I could describe it precisely, then working with AI to build it: iterating, testing, fixing, adjusting until it did exactly what I needed.</p>
-
-      <p>Here's what surprised me, though: the more I did it, the more I started thinking differently.</p>
-
-      <p>When you work with AI to solve real problems, you develop a kind of structured thinking that mirrors how machines process things. You stop saying "it would be nice if…" and start saying "given X input, I want Y output, under these conditions." You anticipate failure modes. You ask: What does done actually look like?</p>
-
-      <p>That's not a programmer skill, it's a thinking skill. AI has made it accessible to anyone willing to play with it.</p>
-
-      <p>The old gatekeeping skill was knowing how to write the code. The new power skill is knowing how to think the problem through.</p>
-
-      <p>If you've been waiting for someone technical to build the things you need — stop waiting. The tools are there. The barrier is lower than you think.</p>
-
-      <p>The only real question is: can you think clearly about what you want?</p>
-
+      <Content />
     </div>
   </article>
 
@@ -127,27 +103,27 @@ const slug = 'you-dont-need-to-code-you-need-to-think';
     max-width: 68ch;
   }
 
-  .prose p {
+  .prose :global(p) {
     font-size: clamp(16px, 1.8vw, 18px);
     line-height: 1.75;
     color: var(--da-ink-muted);
     margin-bottom: 28px;
   }
-  .prose p:first-child {
+  .prose :global(p:first-child) {
     font-size: clamp(18px, 2vw, 22px);
     color: var(--da-ink);
     font-weight: 500;
     line-height: 1.55;
   }
-  .prose p:last-child { margin-bottom: 0; }
+  .prose :global(p:last-child) { margin-bottom: 0; }
 
-  .prose a {
+  .prose :global(a) {
     color: var(--da-accent);
     text-decoration: underline;
     text-underline-offset: 3px;
     transition: opacity 0.15s;
   }
-  .prose a:hover { opacity: 0.7; }
+  .prose :global(a:hover) { opacity: 0.7; }
 
   /* ── Post footer ─────────────────────────────────────────────── */
   .post-footer {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,7 +1,5 @@
 ---
-/**
- * Insights — Blog index
- */
+import { getCollection } from 'astro:content';
 import SiteLayout from '../../layouts/SiteLayout.astro';
 
 const base = import.meta.env.BASE_URL;
@@ -11,15 +9,15 @@ const withBase = (path) => {
   return `${b}${p}`;
 };
 
-const posts = [
-  {
-    slug: 'you-dont-need-to-code-you-need-to-think',
-    title: "You don't need to code. You need to think.",
-    date: '13 June 2026',
-    excerpt:
-      "AI hasn't just made coding easier — it's democratised the most powerful skill in software: the ability to bend machines to your will.",
-  },
-];
+const allPosts = await getCollection('blog');
+const posts = allPosts
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .map(post => ({
+    slug: post.data.slug ?? post.id,
+    title: post.data.title,
+    date: post.data.date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }),
+    excerpt: post.data.description,
+  }));
 ---
 
 <SiteLayout


### PR DESCRIPTION
## Summary

- Adds `src/content.config.ts` — Astro 5 Content Layer config defining a `blog` collection with a Zod schema (title, description, author, date, slug)
- Moves the first article to `src/content/blog/you-dont-need-to-code-you-need-to-think.md` (plain Markdown, frontmatter preserved)
- Replaces the hardcoded `you-dont-need-to-code-you-need-to-think.astro` with a dynamic `[slug].astro` route using `getStaticPaths` + `getCollection` + `render()`
- Updates `blog/index.astro` to drive the post list from `getCollection('blog')`, sorted by date descending

Adding future articles is now a single step: drop a `.md` file into `src/content/blog/`.

## Test plan

- [x] `pnpm build` passes with 0 errors — `/blog/you-dont-need-to-code-you-need-to-think/index.html` generated correctly
- [ ] Verify blog index lists the article card with correct title, date, and "Read more" link
- [ ] Verify article page renders prose, byline, back link, and footer CTA
- [ ] Verify the `[Antony Muriithi](https://...)` hyperlink renders with correct accent/underline styles
- [ ] Verify OG tags (`og:title`, `og:description`) are populated from frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)