### PR TITLE
chore: update sitemap for blog launch

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://skippies-io.github.io/lbdc-website/</loc>
+    <loc>https://www.lbdc.co.za/</loc>
   </url>
   <url>
-    <loc>https://skippies-io.github.io/lbdc-website/services/</loc>
+    <loc>https://www.lbdc.co.za/services/</loc>
   </url>
   <url>
-    <loc>https://skippies-io.github.io/lbdc-website/about/</loc>
+    <loc>https://www.lbdc.co.za/about/</loc>
   </url>
   <url>
-    <loc>https://skippies-io.github.io/lbdc-website/insights/</loc>
+    <loc>https://www.lbdc.co.za/blog/</loc>
   </url>
   <url>
-    <loc>https://skippies-io.github.io/lbdc-website/contact/</loc>
+    <loc>https://www.lbdc.co.za/blog/you-dont-need-to-code-you-need-to-think/</loc>
+  </url>
+  <url>
+    <loc>https://www.lbdc.co.za/contact/</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## What changed

- Updated `public/sitemap.xml` from old GitHub Pages URLs to the live `https://www.lbdc.co.za` domain.
- Replaced the stale `/insights/` sitemap entry with `/blog/` and the published article permalink.
- Closes #32.

## How to test

1. `pnpm run build`
2. Confirm `dist/sitemap.xml` includes `/blog/` and `/blog/you-dont-need-to-code-you-need-to-think/`.

## Evidence

- Local build passed: Astro built 45 pages successfully.
- Generated sitemap verified with live-domain URLs.

## Risk

Low — static XML sitemap-only cleanup.

## Screenshots / Visual proof

Not applicable — no UI change.

## Checklist

- [x] Build passes (`pnpm run build`)
- [x] Screenshots attached/linked (not applicable; no UI change)
- [x] Copy is clearly marked TODO where awaiting LeRoy input (not applicable)
