### PR TITLE
Fix AI Training enquiry CTA routing

### DIFF
--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -153,6 +153,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
       <div class="svc-detail__meta">
         <div class="svc-num">04</div>
         <h2 class="svc-detail__title">AI<br>Training</h2>
+        <a class="btn btn--primary" href="#courses">Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -177,9 +178,6 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
             <h3>Team adoption</h3>
             <p>Hands-on enablement for teams that need shared language, guardrails, and confidence using AI in day-to-day delivery.</p>
           </div>
-        </div>
-        <div class="svc-detail__action">
-          <a class="btn btn--primary" href="#sip-sign-up">Join Sip &amp; Prompt →</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #66

## What changed
- Added the standard Enquire button under the AI Training heading.
- Routed the AI Training enquiry button to the Courses section via #courses.
- Removed the misplaced Join Sip & Prompt CTA from the AI Training content block.

## How to test
- pnpm run build
- Static smoke: inspect dist/services/index.html for AI Training href="#courses".

## Evidence
- pnpm run build passed: 46 static pages built successfully.
- Static smoke confirms AI Training renders Enquire with href="#courses"; Sip & Prompt CTA remains only in Courses.

## Risk
Low — one-page CTA markup change only.

## SonarQube
Not configured for this repo.