### PR TITLE
Improve GBP conversion tracking

### DIFF
--- a/docs/gbp-conversion-pack.md
+++ b/docs/gbp-conversion-pack.md
@@ -1,0 +1,66 @@
+# Google Business Profile Conversion Pack
+
+Use these assets when updating the LBDC Google Business Profile. The matching website work tracks `utm_source=google_business_profile`, `utm_medium=organic`, and campaign/source values through to Google Analytics and Basin form submissions.
+
+## Profile Website Link
+
+Set the primary website link to:
+
+```text
+https://www.lbdc.co.za/services/?utm_source=google_business_profile&utm_medium=organic&utm_campaign=gbp_profile&utm_content=website_button
+```
+
+For AI training posts, use:
+
+```text
+https://www.lbdc.co.za/services/?utm_source=google_business_profile&utm_medium=organic&utm_campaign=gbp_ai_training&utm_content=post_cta#sip-sign-up
+```
+
+If Google strips fragments or query strings, use the services page URL only and keep the UTM values on post CTA links.
+
+## Post 1: AI Training For Teams
+
+**Post type:** Update  
+**CTA:** Learn more  
+**Link:** `https://www.lbdc.co.za/services/?utm_source=google_business_profile&utm_medium=organic&utm_campaign=gbp_ai_training&utm_content=post_1`
+
+Practical AI training for professionals and teams who need to move beyond curiosity. LBDC helps teams write better prompts, design useful AI workflows, and apply automation to real business work.
+
+## Post 2: Product Strategy Support
+
+**Post type:** Update  
+**CTA:** Contact us  
+**Link:** `https://www.lbdc.co.za/contact/?source=gbp_product_strategy&service=product-management&utm_source=google_business_profile&utm_medium=organic&utm_campaign=gbp_product_strategy&utm_content=post_2`
+
+Need clearer product priorities? LBDC supports product teams with roadmaps, OKRs, discovery, prioritisation, and stakeholder alignment that connect digital delivery to business outcomes.
+
+## Post 3: Digital Transformation Delivery
+
+**Post type:** Update  
+**CTA:** Contact us  
+**Link:** `https://www.lbdc.co.za/contact/?source=gbp_digital_transformation&service=digital-transformation&utm_source=google_business_profile&utm_medium=organic&utm_campaign=gbp_digital_transformation&utm_content=post_3`
+
+Transformation should show up in shipped product, not just strategy documents. LBDC helps organisations improve delivery cadence, operating models, platform modernisation, and cross-functional execution.
+
+## Post 4: Online Banking And Payments
+
+**Post type:** Update  
+**CTA:** Contact us  
+**Link:** `https://www.lbdc.co.za/contact/?source=gbp_banking_payments&service=banking-payments&utm_source=google_business_profile&utm_medium=organic&utm_campaign=gbp_banking_payments&utm_content=post_4`
+
+LBDC brings hands-on product experience across online banking, digital payments, mobile banking, payment gateway integration, and pan-African fintech expansion.
+
+## Review Request Template
+
+Hi [Name], thank you again for working with LBDC. If the engagement was useful, would you be willing to leave a short Google review? A few words about the specific work, such as product strategy, AI training, digital transformation, or banking/payments, would help other teams understand where LBDC can help.
+
+## Monthly Reporting Baseline
+
+Track these numbers monthly:
+
+- Google Business Profile views
+- Website clicks from GBP
+- Calls or messages from GBP
+- Form submissions with `utm_source=google_business_profile`
+- Top GBP post by clicks
+- Service area selected on contact forms

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -52,6 +52,35 @@ const navLinks = [
 
 const currentPath = Astro.url.pathname;
 
+const organisationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfessionalService',
+  name: 'LBDC',
+  url: siteUrl(''),
+  logo: siteUrl(withBase('brand/LBDC_logo.png')),
+  image: siteUrl(withBase('og-image.png')),
+  email: 'hello@lbdc.co.za',
+  founder: {
+    '@type': 'Person',
+    name: 'LeRoy Barnes',
+  },
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Johannesburg',
+    addressCountry: 'ZA',
+  },
+  areaServed: [
+    { '@type': 'Country', name: 'South Africa' },
+    { '@type': 'Place', name: 'Africa' },
+  ],
+  serviceType: [
+    'Product management consulting',
+    'Digital transformation consulting',
+    'AI training',
+    'Online banking and digital payments consulting',
+  ],
+};
+
 ---
 
 <!doctype html>
@@ -73,6 +102,7 @@ const currentPath = Astro.url.pathname;
     <meta name="twitter:image" content={siteUrl(withBase('og-image.png'))} />
     <meta name="twitter:image:alt" content="LBDC" />
     <link rel="canonical" href={siteUrl(Astro.url.pathname)} />
+    <script type="application/ld+json" set:html={JSON.stringify(organisationJsonLd)} />
 
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-20KBH2YJCT"></script>
@@ -147,7 +177,14 @@ const currentPath = Astro.url.pathname;
             </div>
           </details>
 
-          <a class="nav__cta" href={withBase('contact/')}>Get in touch</a>
+          <a
+            class="nav__cta"
+            href={withBase('contact/?source=nav_cta')}
+            data-lbdc-track="cta_click"
+            data-lbdc-label="nav_get_in_touch"
+          >
+            Get in touch
+          </a>
           <button class="theme-toggle" type="button" aria-label="Switch to dark mode" aria-pressed="false">
             <span class="theme-toggle__track" aria-hidden="true">
               <span class="theme-toggle__thumb"></span>
@@ -169,7 +206,13 @@ const currentPath = Astro.url.pathname;
       </div>
       <div class="footer__right">
         {navLinks.map(({ href, label }) => (
-          <a href={href}>{label}</a>
+          <a
+            href={href}
+            data-lbdc-track="footer_nav_click"
+            data-lbdc-label={label.toLowerCase()}
+          >
+            {label}
+          </a>
         ))}
       </div>
       <!-- Subtle watermark mark (tasteful, low opacity) -->
@@ -284,6 +327,90 @@ const currentPath = Astro.url.pathname;
         );
 
         countEls.forEach(function (el) { countObserver.observe(el); });
+      })();
+    </script>
+
+    <!-- CONVERSION TRACKING ────────────────────────────────────── -->
+    <script is:inline>
+      (function () {
+        var STORAGE_KEY = 'lbdc-attribution';
+        var TRACKED_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'source', 'service'];
+        var searchParams = new URLSearchParams(window.location.search);
+
+        function readAttribution() {
+          try {
+            return JSON.parse(window.sessionStorage.getItem(STORAGE_KEY) || '{}') || {};
+          } catch (error) {
+            return {};
+          }
+        }
+
+        function writeAttribution(data) {
+          try {
+            window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+          } catch (error) {
+            // Session storage can be unavailable; tracking still works for the current page.
+          }
+        }
+
+        function collectCurrentAttribution() {
+          var attribution = readAttribution();
+          TRACKED_PARAMS.forEach(function (param) {
+            var value = searchParams.get(param);
+            if (value) attribution[param] = value;
+          });
+
+          if (!attribution.landing_page) attribution.landing_page = window.location.href;
+          attribution.current_page = window.location.href;
+          attribution.referrer = document.referrer || attribution.referrer || '';
+          writeAttribution(attribution);
+          return attribution;
+        }
+
+        function trackEvent(name, params) {
+          if (typeof window.gtag !== 'function') return;
+          window.gtag('event', name, params || {});
+        }
+
+        var attribution = collectCurrentAttribution();
+
+        document.querySelectorAll('form').forEach(function (form) {
+          Object.keys(attribution).forEach(function (key) {
+            if (!attribution[key]) return;
+            var inputName = 'attribution_' + key;
+            var input = form.querySelector('input[name="' + inputName + '"]');
+            if (!input) {
+              input = document.createElement('input');
+              input.type = 'hidden';
+              input.name = inputName;
+              form.appendChild(input);
+            }
+            input.value = attribution[key];
+          });
+
+          form.addEventListener('submit', function () {
+            trackEvent('form_submit', {
+              form_id: form.id || 'unknown',
+              source: attribution.source || '',
+              service: attribution.service || '',
+              utm_source: attribution.utm_source || '',
+              utm_campaign: attribution.utm_campaign || ''
+            });
+          });
+        });
+
+        document.querySelectorAll('[data-lbdc-track]').forEach(function (el) {
+          el.addEventListener('click', function () {
+            trackEvent(el.getAttribute('data-lbdc-track'), {
+              event_label: el.getAttribute('data-lbdc-label') || el.textContent.trim(),
+              link_url: el.href || '',
+              source: attribution.source || '',
+              service: attribution.service || '',
+              utm_source: attribution.utm_source || '',
+              utm_campaign: attribution.utm_campaign || ''
+            });
+          });
+        });
       })();
     </script>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -57,6 +57,8 @@ const redirectUrl = `${Astro.site}${withBase('contact/?success=1')}`;
 
           {/* Basin: redirect back to this page with ?success=1 after submission */}
           <input type="hidden" name="_redirect" value={redirectUrl} />
+          <input type="hidden" id="enquiry-source" name="enquiry_source" value="contact_page" />
+          <input type="hidden" id="enquiry-page" name="enquiry_page" value="contact" />
 
           <div class="field">
             <label class="field__label" for="name">Full name <span aria-hidden="true">*</span></label>
@@ -146,7 +148,7 @@ const redirectUrl = `${Astro.site}${withBase('contact/?success=1')}`;
         <div class="sidebar-card">
           <div class="sidebar-card__label">Direct email</div>
           <div class="sidebar-card__value" id="direct-email" data-email-user="hello" data-email-domain="lbdc.co.za">
-            <a class="email-link" href="mailto:hello@lbdc.co.za">hello@lbdc.co.za</a>
+            <a class="email-link" href="mailto:hello@lbdc.co.za" data-lbdc-track="email_click" data-lbdc-label="contact_sidebar_email">hello@lbdc.co.za</a>
             <div class="sidebar-card__hint">If the form fails to submit, email directly.</div>
           </div>
         </div>
@@ -161,10 +163,10 @@ const redirectUrl = `${Astro.site}${withBase('contact/?success=1')}`;
         <div class="sidebar-card sidebar-card--services">
           <div class="sidebar-card__label">Services</div>
           <ul class="sidebar-services">
-            <li><a href={withBase('services/#product-management')}>Product Management &amp; Strategy</a></li>
-            <li><a href={withBase('services/#digital-transformation')}>Digital Transformation</a></li>
-            <li><a href={withBase('services/#banking-payments')}>Online Banking &amp; Digital Payments</a></li>
-            <li><a href={withBase('sip-and-prompt/')}>AI Training / Sip &amp; Prompt</a></li>
+            <li><a href={withBase('services/#product-management')} data-lbdc-track="contact_sidebar_service_click" data-lbdc-label="product_management">Product Management &amp; Strategy</a></li>
+            <li><a href={withBase('services/#digital-transformation')} data-lbdc-track="contact_sidebar_service_click" data-lbdc-label="digital_transformation">Digital Transformation</a></li>
+            <li><a href={withBase('services/#banking-payments')} data-lbdc-track="contact_sidebar_service_click" data-lbdc-label="banking_payments">Online Banking &amp; Digital Payments</a></li>
+            <li><a href={withBase('sip-and-prompt/?source=contact_sidebar')} data-lbdc-track="contact_sidebar_service_click" data-lbdc-label="ai_training">AI Training / Sip &amp; Prompt</a></li>
           </ul>
         </div>
       </div>
@@ -183,6 +185,20 @@ const redirectUrl = `${Astro.site}${withBase('contact/?success=1')}`;
     if (form) form.hidden = true;
     if (success) success.hidden = false;
   }
+
+  const requestedService = params.get('service');
+  const requestedSource = params.get('source');
+  const serviceSelect = document.getElementById('service') as HTMLSelectElement | null;
+  const sourceInput = document.getElementById('enquiry-source') as HTMLInputElement | null;
+  const pageInput = document.getElementById('enquiry-page') as HTMLInputElement | null;
+
+  if (serviceSelect && requestedService) {
+    const hasRequestedOption = Array.from(serviceSelect.options).some((option) => option.value === requestedService);
+    if (hasRequestedOption) serviceSelect.value = requestedService;
+  }
+
+  if (sourceInput && requestedSource) sourceInput.value = requestedSource;
+  if (pageInput) pageInput.value = location.href;
 
   // Client-side validation UX + loading state
   //

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,12 @@ const withBase = (path) => {
   const p = String(path || '').replace(/^\//, '');
   return `${b}${p}`;
 };
+
+const contactUrl = (source, service = '') => {
+  const params = new URLSearchParams({ source });
+  if (service) params.set('service', service);
+  return withBase(`contact/?${params.toString()}`);
+};
 ---
 
 <SiteLayout
@@ -30,8 +36,8 @@ const withBase = (path) => {
       payments, insurance, and applied AI.
     </p>
     <div class="hero__actions" data-enter="3">
-      <a class="btn btn--primary" href={withBase('contact/')}>Get in touch</a>
-      <a class="btn btn--ghost" href={withBase('services/')}>See services →</a>
+      <a class="btn btn--primary" href={contactUrl('home_hero')} data-lbdc-track="cta_click" data-lbdc-label="home_hero_get_in_touch">Get in touch</a>
+      <a class="btn btn--ghost" href={withBase('services/?source=home_hero_services')} data-lbdc-track="cta_click" data-lbdc-label="home_hero_services">See services →</a>
     </div>
 
     <!-- Proof ribbon -->
@@ -73,7 +79,7 @@ const withBase = (path) => {
           Roadmapping, OKRs, and prioritisation frameworks that align
           digital product teams with real business outcomes.
         </p>
-        <a class="svc__link" href={withBase('services/')}>Learn more →</a>
+        <a class="svc__link" href={withBase('services/#product-management')} data-lbdc-track="service_interest_click" data-lbdc-label="home_product_management">Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">02</div>
@@ -83,7 +89,7 @@ const withBase = (path) => {
           cross-functional operating model redesign — from quarterly to
           weekly release cycles.
         </p>
-        <a class="svc__link" href={withBase('services/')}>Learn more →</a>
+        <a class="svc__link" href={withBase('services/#digital-transformation')} data-lbdc-track="service_interest_click" data-lbdc-label="home_digital_transformation">Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">03</div>
@@ -93,7 +99,7 @@ const withBase = (path) => {
           payment gateway integrations, and fintech platforms across
           African markets.
         </p>
-        <a class="svc__link" href={withBase('services/')}>Learn more →</a>
+        <a class="svc__link" href={withBase('services/#banking-payments')} data-lbdc-track="service_interest_click" data-lbdc-label="home_banking_payments">Learn more →</a>
       </article>
       <article class="svc" data-reveal>
         <div class="svc__num">04</div>
@@ -102,7 +108,7 @@ const withBase = (path) => {
           Practical AI training for professionals and teams who need to
           think clearly, prompt well, and apply automation to real work.
         </p>
-        <a class="svc__link" href={withBase('sip-and-prompt/')}>Learn more →</a>
+        <a class="svc__link" href={withBase('sip-and-prompt/?source=home_ai_training')} data-lbdc-track="service_interest_click" data-lbdc-label="home_ai_training">Learn more →</a>
       </article>
     </div>
   </section>
@@ -156,7 +162,7 @@ const withBase = (path) => {
           He works directly with founders and executive teams.
           No account managers, no padding.
         </p>
-        <a class="btn btn--ghost" href={withBase('about/')} style="margin-top: 24px;">About LeRoy →</a>
+        <a class="btn btn--ghost" href={withBase('about/?source=home_about_preview')} style="margin-top: 24px;" data-lbdc-track="cta_click" data-lbdc-label="home_about_preview">About LeRoy →</a>
       </div>
       <div class="about-preview__right" data-reveal>
         <div class="credential">
@@ -190,7 +196,7 @@ const withBase = (path) => {
         Briefly describe what you're trying to achieve.
         LeRoy responds within one to two business days.
       </p>
-      <a class="btn btn--accent btn--lg" href={withBase('contact/')}>Start a conversation →</a>
+      <a class="btn btn--accent btn--lg" href={contactUrl('home_bottom_cta')} data-lbdc-track="cta_click" data-lbdc-label="home_bottom_start_conversation">Start a conversation →</a>
     </div>
   </section>
 

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -19,6 +19,12 @@ const siteUrl = (path) => {
   return p ? `${s}/${p}` : s;
 };
 
+const contactUrl = (source, service = '') => {
+  const params = new URLSearchParams({ source });
+  if (service) params.set('service', service);
+  return withBase(`contact/?${params.toString()}`);
+};
+
 const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'));
 ---
 
@@ -44,7 +50,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
       <div class="svc-detail__meta">
         <div class="svc-num">01</div>
         <h2 class="svc-detail__title">Product Management<br>&amp; Strategy</h2>
-        <a class="btn btn--primary" href={withBase('contact/')}>Enquire →</a>
+        <a class="btn btn--primary" href={contactUrl('services_product_management', 'product-management')} data-lbdc-track="service_enquiry_click" data-lbdc-label="product_management">Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -80,7 +86,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
       <div class="svc-detail__meta">
         <div class="svc-num">02</div>
         <h2 class="svc-detail__title">Digital<br>Transformation</h2>
-        <a class="btn btn--primary" href={withBase('contact/')}>Enquire →</a>
+        <a class="btn btn--primary" href={contactUrl('services_digital_transformation', 'digital-transformation')} data-lbdc-track="service_enquiry_click" data-lbdc-label="digital_transformation">Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -117,7 +123,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
       <div class="svc-detail__meta">
         <div class="svc-num">03</div>
         <h2 class="svc-detail__title">Online Banking &amp;<br>Digital Payments</h2>
-        <a class="btn btn--primary" href={withBase('contact/')}>Enquire →</a>
+        <a class="btn btn--primary" href={contactUrl('services_banking_payments', 'banking-payments')} data-lbdc-track="service_enquiry_click" data-lbdc-label="banking_payments">Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -153,7 +159,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
       <div class="svc-detail__meta">
         <div class="svc-num">04</div>
         <h2 class="svc-detail__title">AI<br>Training</h2>
-        <a class="btn btn--primary" href="#courses">Enquire →</a>
+        <a class="btn btn--primary" href="#courses" data-lbdc-track="service_enquiry_click" data-lbdc-label="ai_training_courses">Enquire →</a>
       </div>
       <div class="svc-detail__body">
         <p class="svc-detail__lead">
@@ -205,7 +211,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
           clearly with AI, write better prompts, and apply automation to
           everyday work.
         </p>
-        <a class="course-card__link" href="#sip-sign-up">Join Sip &amp; Prompt →</a>
+        <a class="course-card__link" href="#sip-sign-up" data-lbdc-track="course_interest_click" data-lbdc-label="sip_and_prompt">Join Sip &amp; Prompt →</a>
       </article>
 
       <article class="course-card" data-reveal>
@@ -216,7 +222,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
           how to sponsor adoption responsibly, and what good governance looks
           like.
         </p>
-        <a class="course-card__link" href={withBase('contact/')}>Enquire →</a>
+        <a class="course-card__link" href={contactUrl('services_ai_executives', 'ai-training')} data-lbdc-track="course_interest_click" data-lbdc-label="ai_for_executives">Enquire →</a>
       </article>
     </div>
   </section>
@@ -360,7 +366,7 @@ const sipPromptRedirectUrl = siteUrl(withBase('services/?sip=1#sip-and-prompt'))
         Every engagement starts with a conversation.
         No pitch, no deck — just a direct discussion about your challenge.
       </p>
-      <a class="btn btn--accent btn--lg" href={withBase('contact/')}>Get in touch →</a>
+      <a class="btn btn--accent btn--lg" href={contactUrl('services_bottom_cta')} data-lbdc-track="cta_click" data-lbdc-label="services_bottom_get_in_touch">Get in touch →</a>
     </div>
   </section>
 


### PR DESCRIPTION
Closes #68

## What changed
- Added session-based attribution capture for UTM/source/service parameters and GA events for CTAs, service links, email clicks, footer links, and form submits.
- Updated homepage/services/contact enquiry paths so service-specific CTAs pre-select the contact form area and preserve source context in Basin submissions.
- Added ProfessionalService structured data and a GBP conversion pack with profile links, four post drafts, review request copy, and monthly reporting metrics.

## How to test
- Run `pnpm build`.
- Open `/contact/?source=gbp_product_strategy&service=product-management&utm_source=google_business_profile` and confirm Product Management & Strategy is selected.
- Submit path evidence: hidden Basin fields include enquiry source/page plus attribution fields.

## Evidence
- `pnpm build` passed: 46 static pages generated.
- `git diff --check` passed.

## Risk
Low. Static-site tracking/link changes only; no new dependencies, no contact detail changes.