### PR TITLE
Add PR build checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,31 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build


### PR DESCRIPTION
## What changed
- Added a pull_request workflow for main that runs the same install and build checks as the Pages deploy path.
- Uses Node 20 and pnpm with a frozen lockfile.

## How to test
- Run `pnpm install --frozen-lockfile`.
- Run `pnpm build`.

## Evidence
- `pnpm install --frozen-lockfile` passed.
- `pnpm build` passed: 46 static pages generated.
- `git diff --check` passed.

## Risk
Low. Adds CI only; no runtime site code changed.