### PR TITLE
Add treasury platform insight article

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,4 +12,15 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+const insights = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/insights' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    author: z.string(),
+    date: z.coerce.date(),
+    slug: z.string().optional(),
+  }),
+});
+
+export const collections = { blog, insights };

--- a/src/content/blog/you-dont-need-to-code-you-need-to-think.md
+++ b/src/content/blog/you-dont-need-to-code-you-need-to-think.md
@@ -1,6 +1,6 @@
 ---
 title: "You don't need to code. You need to think."
-description: "AI hasn't just made coding easier — it's democratised the ability to bend machines to your will. A reflection by LeRoy Barnes."
+description: "AI hasn't just made coding easier, it's democratised the ability to bend machines to your will. A reflection by LeRoy Barnes."
 author: LeRoy Barnes
 date: 2026-06-13
 slug: you-dont-need-to-code-you-need-to-think

--- a/src/content/insights/platform-as-the-next-treasury-frontier.md
+++ b/src/content/insights/platform-as-the-next-treasury-frontier.md
@@ -1,0 +1,61 @@
+---
+title: "Why banking platforms are becoming the next basis of treasury choice"
+description: "Clients already choose banks for relationship, product, pricing and service. The next frontier is whether the bank's platform becomes part of the customer's daily operating rhythm."
+author: LeRoy Barnes
+date: 2026-07-12
+slug: platform-as-the-next-treasury-frontier
+---
+
+Clients already choose banks for relationship, product, pricing and service. Those still matter. In treasury, they may matter more than ever. But the next basis of choice is becoming harder to ignore: whether the bank's platform earns a place in the customer's daily operating rhythm.
+
+That is a different test from having a functional channel. A platform can process payments, show balances and host reports without becoming important to how a treasury team actually works. The stronger question is whether it gives the customer more control, more confidence and fewer gaps in the day.
+
+## Why this matters in treasury
+
+Treasury work is not a single event. It is a sequence of decisions, checks, approvals, exceptions and handovers. Teams need visibility before the day runs away from them. They need execution confidence when payments, liquidity and funding decisions are moving. They need earlier risk signals when something is drifting out of tolerance. They need continuity between the people who decide and the people who operate.
+
+That is why platform strategy matters. The bank that helps a treasury team see, decide and act inside its real workflow becomes more than a provider. It becomes part of the operating model.
+
+This does not replace relationship management. It gives the relationship more evidence. It does not replace product strength. It makes product strength easier to use. It does not replace pricing discipline. It helps the customer understand value in context.
+
+## Two buyers, one platform
+
+There are usually two audiences in this decision.
+
+The executive decision-maker buys control. They care about visibility, governance, risk, service confidence and whether the bank can support the organisation's operating model as it grows. They are not buying screens. They are buying assurance.
+
+The operating user creates the evidence. They feel the friction first: unclear status, manual follow-ups, fragmented reporting, duplicated capture, late exceptions, weak handover between teams. If the platform removes that friction, usage becomes proof. If it does not, the relationship has to carry more weight than it should.
+
+Good platform strategy connects those two realities. It gives executives a stronger control story and gives operators a better working day.
+
+## The daily operating rhythm test
+
+For a treasury platform, adoption is not just a login count. The practical test is simpler.
+
+Does the platform earn usage in the morning, when teams need a clear view of positions, obligations and exceptions?
+
+Does it earn usage midday, when execution, approvals and customer service pressure are live?
+
+Does it earn usage in the afternoon, when teams need to reconcile what happened, understand what is still exposed and prepare for tomorrow?
+
+If the answer is yes, the platform is becoming part of the customer's rhythm. If the answer is no, it may still be useful, but it is not yet strategic.
+
+## The worked-example lens
+
+In a recent strategy case, the starting point was a bank with strong relationship, product, pricing and service advantages. The question was not how to ignore those strengths and chase a digital fashion. The question was how to turn them into a platform experience that customers would rely on through the day.
+
+That shift changes the work. The product conversation moves from feature inventory to workflow importance. The digital conversation moves from channel delivery to customer operating rhythm. The commercial conversation moves from "what can we sell?" to "where can we become harder to replace?"
+
+That is the frontier.
+
+## What this means for banks and platform teams
+
+Platform strategy is not a pivot away from existing strengths. It is the evolution of them.
+
+For banks, this means treating digital treasury platforms as strategic assets, not only service channels. Product, relationship, operations and technology teams need a shared view of the customer workflow they are trying to earn. The roadmap should show how the bank becomes more useful at the moments that matter most.
+
+For platform teams, it means asking harder questions than whether a feature can be built. Which decision does it support? Which risk does it surface earlier? Which manual step does it remove? Which moment of the day does it improve? Which evidence will tell us that customers are actually relying on it?
+
+The banks that answer those questions well will not win only because they have a platform. They will win because the platform makes their existing strengths show up inside the customer's work.
+
+If your platform is strong but not yet part of the customer's daily operating rhythm, LBDC can help turn that into product strategy.

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -46,7 +46,7 @@ const siteUrl = (path: string) => {
 const navLinks = [
   { href: withBase('about/'),    label: 'About' },
   { href: withBase('services/'), label: 'Services' },
-  { href: withBase('blog/'),     label: 'Insights' },
+  { href: withBase('insights/'), label: 'Insights' },
   { href: withBase('contact/'),  label: 'Contact' },
 ];
 

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -1,7 +1,8 @@
 ---
 /**
- * Insights — Coming soon
+ * Insights
  */
+import { getCollection } from 'astro:content';
 import SiteLayout from '../layouts/SiteLayout.astro';
 
 const base = import.meta.env.BASE_URL;
@@ -10,40 +11,127 @@ const withBase = (path) => {
   const p = String(path || '').replace(/^\//, '');
   return `${b}${p}`;
 };
+
+const allPosts = await getCollection('insights');
+const posts = allPosts
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .map(post => ({
+    slug: post.data.slug ?? post.id,
+    title: post.data.title,
+    date: post.data.date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }),
+    excerpt: post.data.description,
+  }));
 ---
 
 <SiteLayout
   title="Insights"
-  description="Insights from LBDC — coming soon."
+  description="LBDC insights on product strategy, platform differentiation, treasury workflow and digital transformation."
 >
   <section class="page-hero section">
     <div class="label" data-enter="0">Insights</div>
-    <h1 class="page-hero__h1" data-enter="1">Coming soon.</h1>
+    <h1 class="page-hero__h1" data-enter="1">Clear thinking from the field.</h1>
     <p class="page-hero__sub" data-enter="2">
-      Short, practical notes on product strategy, digital transformation, and payments —
-      written from the field.
+      LBDC notes on product strategy, platform differentiation, treasury workflow,
+      digital transformation and payments.
     </p>
+  </section>
 
-    <div class="insights-cta" data-enter="3">
-      <a class="btn btn--primary" href={withBase('contact/')}>Get in touch →</a>
-      <div class="insights-cta__hint">Want a specific topic covered? Tell me what you're working on.</div>
-    </div>
+  <section class="section post-list">
+    {posts.map((post) => (
+      <article class="post-card" data-reveal>
+        <div class="post-card__meta">
+          <span class="post-card__date">{post.date}</span>
+        </div>
+        <div>
+          <h2 class="post-card__title">{post.title}</h2>
+          <p class="post-card__excerpt">{post.excerpt}</p>
+          <a class="post-card__link" href={withBase(`insights/${post.slug}/`)}>
+            Read more →
+          </a>
+        </div>
+      </article>
+    ))}
   </section>
 
   <style>
-    .insights-cta {
-      margin-top: 18px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-      align-items: flex-start;
+    .page-hero { border-top: none; }
+    .page-hero__h1 {
+      font-size: var(--da-display);
+      font-weight: 700;
+      letter-spacing: var(--da-track-tight);
+      line-height: var(--da-lead-tight);
+      margin-bottom: 24px;
+      max-width: 12ch;
+    }
+    .page-hero__sub {
+      font-size: var(--da-body-lg);
+      color: var(--da-ink-muted);
+      max-width: 62ch;
+      line-height: 1.6;
     }
 
-    .insights-cta__hint {
-      font-size: 13px;
-      font-weight: 500;
+    .post-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .post-card {
+      padding: 48px 0;
+      border-bottom: 1px solid var(--da-line);
+      display: grid;
+      grid-template-columns: 160px 1fr;
+      gap: 0 48px;
+      align-items: start;
+    }
+    .post-card:first-child { border-top: 1px solid var(--da-line); }
+
+    .post-card__meta {
+      padding-top: 4px;
+    }
+    .post-card__date {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
       color: var(--da-ink-faint);
-      max-width: 56ch;
+      text-transform: uppercase;
+    }
+
+    .post-card__title {
+      font-size: clamp(20px, 2.4vw, 28px);
+      font-weight: 700;
+      letter-spacing: var(--da-track-head);
+      line-height: 1.2;
+      margin-bottom: 12px;
+      color: var(--da-ink);
+    }
+
+    .post-card__excerpt {
+      font-size: 15px;
+      color: var(--da-ink-muted);
+      line-height: 1.65;
+      max-width: 64ch;
+      margin-bottom: 20px;
+    }
+
+    .post-card__link {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--da-accent);
+      letter-spacing: 0.01em;
+      transition: opacity 0.15s;
+    }
+    .post-card__link:hover { opacity: 0.7; }
+
+    @media (max-width: 640px) {
+      .post-card {
+        grid-template-columns: 1fr;
+        gap: 12px;
+        padding: 36px 0;
+      }
     }
   </style>
 </SiteLayout>

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -1,0 +1,169 @@
+---
+import { getCollection, render } from 'astro:content';
+import SiteLayout from '../../layouts/SiteLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('insights');
+  return posts.map(post => ({
+    params: { slug: post.data.slug ?? post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const base = import.meta.env.BASE_URL;
+const withBase = (path) => {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = String(path || '').replace(/^\//, '');
+  return `${b}${p}`;
+};
+
+const { title, description, author, date } = post.data;
+const formattedDate = date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+---
+
+<SiteLayout title={title} description={description}>
+  <section class="post-hero section">
+    <a class="back-link" href={withBase('insights/')} data-enter="0">← Insights</a>
+    <div class="label" data-enter="1">LBDC insight</div>
+    <h1 class="post-hero__h1" data-enter="2">{title}</h1>
+    <p class="post-hero__deck" data-enter="3">{description}</p>
+    <div class="post-hero__byline" data-enter="4">
+      <span class="byline__author">{author}</span>
+      <span class="byline__sep">—</span>
+      <span class="byline__date">{formattedDate}</span>
+    </div>
+  </section>
+
+  <article class="post-body section">
+    <div class="prose" data-reveal>
+      <Content />
+    </div>
+  </article>
+
+  <section class="section post-footer">
+    <div class="post-footer__inner" data-reveal>
+      <div class="label">Continue reading</div>
+      <a class="back-link-lg" href={withBase('insights/')}>← All insights</a>
+    </div>
+    <div class="post-footer__cta" data-reveal>
+      <div class="label">Work with LBDC</div>
+      <p class="post-footer__cta-text">
+        Need to turn a strong platform into a sharper product strategy?
+      </p>
+      <a class="btn btn--accent" href={withBase('contact/?source=insight_platform_treasury')}>
+        Get in touch →
+      </a>
+    </div>
+  </section>
+</SiteLayout>
+
+<style>
+  .post-hero { border-top: none; }
+
+  .back-link {
+    display: inline-block;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--da-accent);
+    letter-spacing: 0.01em;
+    margin-bottom: 24px;
+    transition: opacity 0.15s;
+  }
+  .back-link:hover { opacity: 0.7; }
+
+  .post-hero__h1 {
+    font-size: clamp(32px, 5vw, 64px);
+    font-weight: 700;
+    letter-spacing: var(--da-track-tight);
+    line-height: var(--da-lead-tight);
+    margin-bottom: 20px;
+    max-width: 21ch;
+  }
+
+  .post-hero__deck {
+    font-size: var(--da-body-lg);
+    color: var(--da-ink-muted);
+    line-height: 1.6;
+    max-width: 62ch;
+    margin-bottom: 22px;
+  }
+
+  .post-hero__byline {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    color: var(--da-ink-muted);
+  }
+  .byline__author { font-weight: 600; color: var(--da-ink); }
+  .byline__sep { color: var(--da-ink-faint); }
+
+  .post-body { background: var(--da-surface); }
+
+  .prose {
+    max-width: 68ch;
+  }
+
+  .prose :global(p) {
+    font-size: clamp(16px, 1.8vw, 18px);
+    line-height: 1.75;
+    color: var(--da-ink-muted);
+    margin-bottom: 28px;
+  }
+
+  .prose :global(p:first-child) {
+    font-size: clamp(18px, 2vw, 22px);
+    color: var(--da-ink);
+    font-weight: 500;
+    line-height: 1.55;
+  }
+
+  .prose :global(h2) {
+    font-size: clamp(22px, 2.4vw, 30px);
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: var(--da-track-head);
+    color: var(--da-ink);
+    margin: 46px 0 18px;
+  }
+
+  .prose :global(p:last-child) { margin-bottom: 0; }
+
+  .post-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 40px;
+  }
+
+  .back-link-lg {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--da-accent);
+    transition: opacity 0.15s;
+  }
+  .back-link-lg:hover { opacity: 0.7; }
+
+  .post-footer__cta { text-align: right; }
+  .post-footer__cta-text {
+    font-size: 15px;
+    color: var(--da-ink-muted);
+    margin-bottom: 16px;
+    max-width: 40ch;
+    line-height: 1.55;
+  }
+
+  @media (max-width: 640px) {
+    .post-footer {
+      flex-direction: column;
+      gap: 32px;
+    }
+    .post-footer__cta { text-align: left; }
+  }
+</style>


### PR DESCRIPTION
Closes #71\n\n## What changed\n- Added a dedicated LBDC insight article at /insights/platform-as-the-next-treasury-frontier/.\n- Replaced the /insights coming-soon page with an insights listing and routed the nav Insights link to /insights/.\n- Corrected the AI article summary punctuation.\n\n## How to test\n- pnpm build\n- pnpm exec astro preview --host 127.0.0.1 --port 4321\n- curl -sS -I http://127.0.0.1:4321/insights/platform-as-the-next-treasury-frontier/\n\n## Evidence\n- pnpm build: passed; Astro built 47 pages including /insights/platform-as-the-next-treasury-frontier/index.html.\n- Local preview smoke: route returned HTTP/1.1 200 OK.\n- Content smoke: preview HTML contains the article title, daily operating rhythm language, and Work with LBDC CTA.\n\n## Risk\nLow. Static Astro content/routes only; no external announcements or publishing actions.