### PR TITLE
Show legacy blog article on Insights

### DIFF
--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -12,8 +12,9 @@ const withBase = (path) => {
   return `${b}${p}`;
 };
 
-const allPosts = await getCollection('insights');
-const posts = allPosts
+const insightPosts = await getCollection('insights');
+const blogPosts = await getCollection('blog');
+const posts = [...insightPosts, ...blogPosts]
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .map(post => ({
     slug: post.data.slug ?? post.id,

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -3,7 +3,10 @@ import { getCollection, render } from 'astro:content';
 import SiteLayout from '../../layouts/SiteLayout.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('insights');
+  const insightPosts = await getCollection('insights');
+  const blogPosts = await getCollection('blog');
+  const posts = [...insightPosts, ...blogPosts];
+
   return posts.map(post => ({
     params: { slug: post.data.slug ?? post.id },
     props: { post },
@@ -51,9 +54,9 @@ const formattedDate = date.toLocaleDateString('en-GB', { day: 'numeric', month: 
     <div class="post-footer__cta" data-reveal>
       <div class="label">Work with LBDC</div>
       <p class="post-footer__cta-text">
-        Need to turn a strong platform into a sharper product strategy?
+        Need clearer product strategy or sharper digital execution?
       </p>
-      <a class="btn btn--accent" href={withBase('contact/?source=insight_platform_treasury')}>
+      <a class="btn btn--accent" href={withBase('contact/?source=insight_article')}>
         Get in touch →
       </a>
     </div>


### PR DESCRIPTION
Closes #73\n\n## What changed\n- /insights/ now combines the new insights collection with the existing blog collection.\n- The previous article now appears on the Insights listing.\n- /insights/you-dont-need-to-code-you-need-to-think/ is generated while the original /blog route remains available.\n\n## How to test\n- pnpm build\n- rg -n "Why banking platforms|You don't need to code|insights/you-dont-need-to-code" dist/insights/index.html\n\n## Evidence\n- pnpm build passed; Astro built 48 pages.\n- Generated /insights/index.html contains both article titles.\n- Generated /insights/you-dont-need-to-code-you-need-to-think/index.html contains the previous article.\n\n## Risk\nLow. Static route/listing fix only.