### PR TITLE
Show Insights articles immediately

### DIFF
--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -39,7 +39,7 @@ const posts = [...insightPosts, ...blogPosts]
 
   <section class="section post-list">
     {posts.map((post) => (
-      <article class="post-card" data-reveal>
+      <article class="post-card">
         <div class="post-card__meta">
           <span class="post-card__date">{post.date}</span>
         </div>


### PR DESCRIPTION
Closes #75\n\n## What changed\n- Removed scroll-reveal from the /insights/ article cards so they render visibly as soon as the page loads.\n- Kept the existing Insights layout, routes and article content structure unchanged.\n\n## How to test\n- pnpm build\n- rg -n "<article class=\"post-card\"|data-reveal" dist/insights/index.html\n\n## Evidence\n- pnpm build passed; Astro built 48 pages.\n- Generated /insights/index.html has visible post-card articles without data-reveal on the cards.\n\n## Risk\nLow. One attribute removed from the Insights listing only.