### PR TITLE
Show article body immediately

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -40,7 +40,7 @@ const formattedDate = date.toLocaleDateString('en-GB', { day: 'numeric', month: 
 
   <!-- ARTICLE BODY ──────────────────────────────────────────────── -->
   <article class="post-body section">
-    <div class="prose" data-reveal>
+    <div class="prose">
       <Content />
     </div>
   </article>

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -41,7 +41,7 @@ const formattedDate = date.toLocaleDateString('en-GB', { day: 'numeric', month: 
   </section>
 
   <article class="post-body section">
-    <div class="prose" data-reveal>
+    <div class="prose">
       <Content />
     </div>
   </article>


### PR DESCRIPTION
Closes #77\n\n## What changed\n- Removed scroll-reveal from the main article body on /insights/[slug].\n- Removed the same reveal gate from the legacy /blog/[slug] article template.\n- Kept footer reveal/CTA effects unchanged.\n\n## How to test\n- pnpm build\n- rg -n "<div class=\"prose\"|data-reveal" dist/insights/platform-as-the-next-treasury-frontier/index.html dist/insights/you-dont-need-to-code-you-need-to-think/index.html dist/blog/you-dont-need-to-code-you-need-to-think/index.html\n\n## Evidence\n- pnpm build passed; Astro built 48 pages.\n- Generated article HTML shows body containers as <div class="prose"> without data-reveal.\n\n## Risk\nLow. Static template attribute removal only.