### PR TITLE
Show all Insights-related primary content immediately

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -40,7 +40,7 @@ const posts = allPosts
   <!-- POST LIST ───────────────────────────────────────────────── -->
   <section class="section post-list">
     {posts.map((post) => (
-      <article class="post-card" data-reveal>
+      <article class="post-card">
         <div class="post-card__meta">
           <span class="post-card__date">{post.date}</span>
         </div>


### PR DESCRIPTION
Closes #79\n\n## What changed\n- Removed scroll-reveal from the legacy /blog/ article card.\n- Completed the audit of Insights-related primary content: /insights/, /insights/[slug], /blog/, and /blog/[slug].\n- Kept lower-page footer/CTA reveal effects unchanged.\n\n## How to test\n- pnpm build\n- rg -n "<article class=\"post-card\"|<div class=\"prose\"|data-reveal" dist/insights/index.html dist/blog/index.html dist/insights/platform-as-the-next-treasury-frontier/index.html dist/insights/you-dont-need-to-code-you-need-to-think/index.html dist/blog/you-dont-need-to-code-you-need-to-think/index.html\n\n## Evidence\n- pnpm build passed; Astro built 48 pages.\n- Generated primary content uses visible post-card/prose containers without data-reveal.\n- Remaining data-reveal instances are footer/CTA sections below the primary content.\n\n## Risk\nLow. Static template attribute removal only.