### PR TITLE
Fix legacy /home indexing 404

### DIFF
--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -1,0 +1,21 @@
+---
+const destination = '/';
+---
+
+<!doctype html>
+<html lang="en-ZA">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content={`0; url=${destination}`} />
+    <meta name="robots" content="noindex, follow" />
+    <link rel="canonical" href="https://www.lbdc.co.za/" />
+    <title>Redirecting to LBDC</title>
+    <script is:inline>
+      window.location.replace('/');
+    </script>
+  </head>
+  <body>
+    <p><a href="/">Continue to LBDC</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## What changed
- Added a legacy /home compatibility page so Google's discovered /home URL no longer returns 404.
- Canonicalises /home back to the real homepage at https://www.lbdc.co.za/.
- Keeps /home out of the sitemap through the existing manual sitemap list.

## How to test
- pnpm run build
- pnpm run verify:seo
- curl -I http://127.0.0.1:4322/home after astro preview

## Evidence
- Build passed locally.
- SEO verification passed: 8 sitemap URLs checked.
- Local preview returned HTTP 200 for /home.

## Risk
Low: static compatibility route only; no existing page behaviour changed.