### PR TITLE
Allow Search Console to inspect /home compatibility page

### DIFF
--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -8,7 +8,6 @@ const destination = '/';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="refresh" content={`0; url=${destination}`} />
-    <meta name="robots" content="noindex, follow" />
     <link rel="canonical" href="https://www.lbdc.co.za/" />
     <title>Redirecting to LBDC</title>
     <script is:inline>


### PR DESCRIPTION
## What changed
- Removed the robots noindex tag from the /home compatibility page.
- Kept the canonical tag pointing to https://www.lbdc.co.za/ so /home does not become the preferred page.

## How to test
- pnpm run build
- pnpm run verify:seo
- Confirm dist/home/index.html has canonical + refresh and no robots noindex tag.

## Evidence
- Build passed locally.
- SEO verification passed: 8 sitemap URLs checked.
- Rendered /home output no longer contains a robots noindex tag.

## Risk
Low: one metadata line removed from the compatibility route only.