### PR TITLE
Fix legacy home indexing signal

### DIFF
--- a/scripts/verify-seo.mjs
+++ b/scripts/verify-seo.mjs
@@ -42,4 +42,12 @@ for (const url of urls) {
   }
 }
 
+const legacyHome = await readFile('dist/home/index.html', 'utf8');
+if (legacyHome.includes('name="robots" content="noindex')) {
+  throw new Error('Legacy /home/ compatibility page must not emit noindex.');
+}
+if (!legacyHome.includes(`<link rel="canonical" href="${SITE}/"`)) {
+  throw new Error('Legacy /home/ compatibility page must canonicalise to the live home page.');
+}
+
 console.log(`SEO verification passed: ${urls.length} sitemap URLs checked.`);

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -8,7 +8,6 @@ const destination = '/';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="refresh" content={`0; url=${destination}`} />
-    <meta name="robots" content="noindex, follow" />
     <link rel="canonical" href="https://www.lbdc.co.za/" />
     <title>Redirecting to LBDC</title>
     <script is:inline>


### PR DESCRIPTION
## What changed
- Removed the `noindex` robots tag from the legacy `/home/` compatibility page while preserving the canonical to the live homepage.
- Added SEO verification coverage so `/home/` cannot regress to `noindex` and must canonicalise to `https://www.lbdc.co.za/`.

## Why
Google Search Console emails on 2026-08-07 reported failed Page indexing validation for `lbdc.co.za`:
- `Page with redirect`
- `Alternate page with proper canonical tag`

The live `/home/` compatibility path is a likely affected URL because it exists for old links, redirects users to `/`, and should remain crawlable enough for Google to process the canonical.

Related historical issue: #36

## How to test
- `CI=true pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm verify:seo`
- Confirm generated `dist/home/index.html` contains the canonical and no `noindex` robots tag.

## Evidence
- `pnpm build` passed: 49 static pages built.
- `pnpm verify:seo` passed: 8 sitemap URLs checked.
- `rg -n "noindex|canonical" dist/home/index.html dist/index.html` showed `/home/` canonicalising to `https://www.lbdc.co.za/` and no `noindex` match.

## Risk
Low. This only changes crawler metadata on the legacy compatibility page and adds verification coverage.
